### PR TITLE
Fix: Broken autocomplete since v2.0 in Korean

### DIFF
--- a/py/prompt_csv.py
+++ b/py/prompt_csv.py
@@ -69,7 +69,7 @@ def get_tag_data():
 @server.PromptServer.instance.routes.get("/erenodes/search_tags")
 async def search_tags(request):
     query = request.query.get("query", "").lower().strip().replace('_', ' ')
-    limit = int(request.query.get("limit", 10))
+    limit = int(request.query.get("limit", 20)) # Sync to frontend
 
     if not query or len(query) < 1:
         return web.json_response([])

--- a/web/js/contextmenu.js
+++ b/web/js/contextmenu.js
@@ -606,6 +606,8 @@ export class TagContextMenu extends DynamicContextMenu {
         this.currentWord = ""; 
         this.filterBox = null;
         
+        this.limit = app.ui.settings.getSettingValue('EreNodes.Autocomplete.Limit', 20);
+        
         // Determine how to position the menu
         if (event instanceof MouseEvent) {
             this.positioning = { event };
@@ -618,7 +620,7 @@ export class TagContextMenu extends DynamicContextMenu {
         this.currentWord = query;
         let suggestions = [];
         try {
-            const response = await fetch(`/erenodes/search_tags?query=${encodeURIComponent(query)}&limit=20`);
+            const response = await fetch(`/erenodes/search_tags?query=${encodeURIComponent(query)}&limit=${this.limit}`);
             if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
             const tags = await response.json();
             suggestions = tags.filter(tag => !this.existingTags.some(existingTag => existingTag.name === tag.name && existingTag.type === 'tag'));

--- a/web/js/settings.js
+++ b/web/js/settings.js
@@ -40,6 +40,28 @@ app.registerExtension({
         });
 
         app.ui.settings.addSetting({
+            id: "EreNodes.Autocomplete.Limit",
+            name: "Autocomplete Suggestion Limit",
+            type: "number",
+            defaultValue: 20,
+            attrs: {
+                min: 1,
+                max: 100,
+                step: 1
+            },
+            onChange: (newVal) => {
+                fetch("/erenodes/set_setting", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        key: "autocomplete.limit",
+                        value: Number.parseInt(newVal)
+                    }),
+                });
+            },
+        });
+
+        app.ui.settings.addSetting({
             id: "EreNodes.Nodes.PasteAction",
             name: "Paste Action",
             type: "combo",

--- a/web/prompt_autocomplete.js
+++ b/web/prompt_autocomplete.js
@@ -210,6 +210,7 @@ class GlobalAutocomplete {
         this.attachedElement = inputElement;
         this.helper = new TextAreaCaretHelper(inputElement);
         this.attachedElement.addEventListener("keydown", this.onKeyDown, true);
+        this.attachedElement.addEventListener("input", this.onInput.bind(this));
         this.attachedElement.addEventListener("blur", this.onBlur);
         this.attachedElement.addEventListener("click", this.onClick);
     }
@@ -217,6 +218,7 @@ class GlobalAutocomplete {
     detach() {
         if (this.attachedElement) {
             this.attachedElement.removeEventListener("keydown", this.onKeyDown, true);
+            this.attachedElement.removeEventListener("input", this.onInput);
             this.attachedElement.removeEventListener("blur", this.onBlur);
             this.attachedElement.removeEventListener("click", this.onClick);
             this.attachedElement = null;
@@ -296,6 +298,11 @@ class GlobalAutocomplete {
         
         // Handle regular character input.
         if (e.key.length === 1) {
+            // Skip if IME composition is in progress (will be handled by onInput instead)
+            if (e.isComposing) {
+                return;
+            }
+            
             // If a separator is typed, close the menu.
             if (/[,;"|}()\n]/.test(e.key)) {
                 this.closeMenu();
@@ -303,6 +310,22 @@ class GlobalAutocomplete {
                 // Otherwise, it's a word character, so show suggestions.
                 this.scheduleUpdate();
             }
+        }
+    }
+
+    onInput(e) {
+        // Handle IME input (Korean, Japanese, Chinese, etc.)
+        // This event fires after composition is complete
+        if (!e.data) return;
+
+        const lastChar = e.data.slice(-1);
+
+        // If a separator is typed, close the menu
+        if (/[,;\"|}()\n]/.test(lastChar)) {
+            this.closeMenu();
+        } else {
+            // Otherwise, it's a word character, so show suggestions.
+            this.scheduleUpdate();
         }
     }
 
@@ -346,9 +369,16 @@ class GlobalAutocomplete {
         const match = before.match(/([^,;"|}()\n]+)$/);
         if (match) {
             const word = match[0].replace(/^\s+/, "").replace(/\s/g, "_") || null;
-            if (word && word.length >= 2) {
-                this.currentWordStart = before.length - match[0].length;
-                return word;
+            if (word) {
+                // For non-ASCII characters (Korean, Japanese, Chinese, etc.), 1 character is enough
+                // For ASCII characters (English), require at least 2 characters
+                const hasNonAscii = /[^\x00-\x7F]/.test(word);
+                const minLength = hasNonAscii ? 1 : 2;
+
+                if (word.length >= minLength) {
+                    this.currentWordStart = before.length - match[0].length;
+                    return word;
+                }
             }
         }
         return null;
@@ -540,8 +570,11 @@ if (typeof app !== "undefined") {
                 !e.target.classList.contains('comfy-context-menu-filter') && // Explicitly don't attach to the searchbox itself via this listener
                 (!app.globalAutocompleteInstance.textarea || app.globalAutocompleteInstance.textarea !== e.target) // Only attach if not already attached or attached to a different element
             ) {
+                // prompt_autocomplete.js:544 
+                // Uncaught ReferenceError: triggerImmediately is not defined
+                app.globalAutocompleteInstance.attach(e.target)
                 // Attach with default behavior for global textareas
-                app.globalAutocompleteInstance.attach(e.target, null, new Set(), e.target, "", triggerImmediately);
+                // app.globalAutocompleteInstance.attach(e.target, null, new Set(), e.target, "", triggerImmediately);
             }
         }
     });


### PR DESCRIPTION
## Summary
This PR tries to fix autocomplete issue in Korean.

`keydown` event won't fire until a word is created so I switched `keydown` to `input` event.

It should be okay with already existing debouncing.

## And
This PR also adds configurable autocomplete limit feature.

It would be simple addition so feel free to comment about them :)