### PR TITLE
Fix nodes on the current frontend and support Vue nodes 2.0

### DIFF
--- a/web/js/contextmenu.js
+++ b/web/js/contextmenu.js
@@ -1,6 +1,72 @@
 import { app } from "../../../../scripts/app.js";
 import { getCache, clearCache } from "./cache.js";
 
+// The frontend's .litemenu-entry rules assume a single line of text (fixed height / line-height),
+// so multi-line tag entries (name + aliases) spill over their neighbours. These styles isolate our
+// own entries from that assumption.
+const TAG_MENU_STYLE_ID = "erenodes-tag-menu-styles";
+function injectTagMenuStyles() {
+    if (document.getElementById(TAG_MENU_STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = TAG_MENU_STYLE_ID;
+    style.textContent = `
+        .erenodes-tag-menu {
+            height: auto !important;
+            overflow-y: auto !important;
+            overflow-x: hidden !important;
+            max-width: min(420px, 90vw);
+        }
+        .erenodes-tag-entry {
+            display: block !important;
+            position: relative !important;
+            box-sizing: border-box !important;
+            width: 100% !important;
+            height: auto !important;
+            min-height: 0 !important;
+            max-height: none !important;
+            line-height: 1.25 !important;
+            white-space: normal !important;
+            overflow: hidden !important;
+            padding: 3px 8px !important;
+        }
+        .erenodes-tag-row {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 10px;
+            line-height: 1.25;
+        }
+        .erenodes-tag-name {
+            flex: 1 1 auto;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .erenodes-tag-count {
+            flex: 0 0 auto;
+            font-size: 0.8em;
+            opacity: 0.7;
+        }
+        .erenodes-tag-aliases {
+            display: block;
+            margin-top: 1px;
+            font-size: 0.8em;
+            line-height: 1.2;
+            opacity: 0.7;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    `;
+    document.head.appendChild(style);
+}
+injectTagMenuStyles();
+
+function escapeAttr(text) {
+    return String(text).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 // Base class for dynamic context menus
 export class DynamicContextMenu { // Added export
     constructor(event, onSelectCallback) {
@@ -647,13 +713,16 @@ export class TagContextMenu extends DynamicContextMenu {
 
         if (option.type === 'tag' && (option.count || option.aliases?.length > 0)) {
             // This is a "rich" tag from the database
-            item.className = "litemenu-entry submenu";
+            item.className = "litemenu-entry submenu erenodes-tag-entry";
             if (option.disabled) item.classList.add("disabled");
 
             const displayHTML = this.highlight(option.name, query);
-            let countHTML = option.count ? `<div style="font-size: 0.8em; opacity: 0.7; margin-left: 10px;">(${option.count.toLocaleString()})</div>` : '';
-            let aliasesHTML = (option.aliases && option.aliases.length) ? `<div style="font-size: 0.8em; opacity: 0.7;">${option.aliases.map(a => this.highlight(a, query)).join(', ')}</div>` : '';
-            item.innerHTML = `<div style="display: flex; justify-content: space-between; align-items: center;"><div>${displayHTML}</div>${countHTML}</div>${aliasesHTML}`;
+            const countHTML = option.count ? `<span class="erenodes-tag-count">(${option.count.toLocaleString()})</span>` : '';
+            const aliases = option.aliases?.length ? option.aliases : null;
+            const aliasesHTML = aliases
+                ? `<div class="erenodes-tag-aliases" title="${escapeAttr(aliases.join(', '))}">${aliases.map(a => this.highlight(a, query)).join(', ')}</div>`
+                : '';
+            item.innerHTML = `<div class="erenodes-tag-row"><span class="erenodes-tag-name" title="${escapeAttr(option.name)}">${displayHTML}</span>${countHTML}</div>${aliasesHTML}`;
 
             item.addEventListener("click", (e) => {
                 e.stopPropagation();
@@ -673,7 +742,7 @@ export class TagContextMenu extends DynamicContextMenu {
     show() {
         this.close();
         this.root = document.createElement("div");
-        this.root.className = "litegraph litecontextmenu litemenubar-panel dark";
+        this.root.className = "litegraph litecontextmenu litemenubar-panel dark erenodes-tag-menu";
         this.root.close = this.close.bind(this);
 
         if (this.positioning?.event) {

--- a/web/js/contextmenu.js
+++ b/web/js/contextmenu.js
@@ -1121,9 +1121,26 @@ export class TagEditContextMenu extends DynamicContextMenu {
                 break;
             }
 
-            default:
+            default: {
                 super.renderSingleItem(item, option, index);
+
+                // Lora / group / embedding names can be far longer than the menu is wide.
+                // Let the row wrap and grow instead of spilling over the next one, which
+                // is how a long name ended up covering the strength control.
+                const growable = {
+                    height: "auto",
+                    "min-height": "0",
+                    "max-height": "none",
+                    "line-height": "normal",
+                    "white-space": "normal",
+                    "overflow-wrap": "anywhere",
+                    position: "static"
+                };
+                for (const [prop, value] of Object.entries(growable)) {
+                    item.style.setProperty(prop, value, "important");
+                }
                 break;
+            }
         }
     }
 

--- a/web/js/contextmenu.js
+++ b/web/js/contextmenu.js
@@ -1082,17 +1082,44 @@ export class TagEditContextMenu extends DynamicContextMenu {
                 });
                 break;
             
-            case 'info_panel':
+            case 'info_panel': {
                 item.className = "litemenu-entry submenu disabled";
-                item.style.cssText = "max-width: 256px; display: flex; flex-wrap: wrap; gap: 2.5px; opacity: 1;";
-                // Apply half opacity only for non-interactive group previews
-                if (this.tag.type === 'group') {
-                    item.style.opacity = "0.6";
+
+                // A menu entry is a single-line row, and the wrapped pill rows have to
+                // grow it. Set with !important so that whatever constrains the row height
+                // can't keep the extra rows out of the flow - otherwise the menu items
+                // after this one are laid out over the pills.
+                const layout = {
+                    display: "flex",
+                    "flex-wrap": "wrap",
+                    "align-content": "flex-start",
+                    gap: "2.5px",
+                    // Block level with auto width: fills the menu instead of the old
+                    // hardcoded 256px box, which sat narrower than every other row.
+                    width: "auto",
+                    "max-width": "100%",
+                    "box-sizing": "border-box",
+                    // The entry background is what showed through as a coloured block
+                    // around the pills - the pills bring their own.
+                    background: "transparent",
+                    height: "auto",
+                    "min-height": "0",
+                    "max-height": "none",
+                    position: "static",
+                    overflow: "hidden",
+                    "line-height": "normal",
+                    // Half opacity only for non-interactive group previews
+                    opacity: this.tag.type === 'group' ? "0.6" : "1"
+                };
+                for (const [prop, value] of Object.entries(layout)) {
+                    item.style.setProperty(prop, value, "important");
                 }
+
                 if (Array.isArray(option.content)) {
                     option.content.forEach(pill => item.appendChild(pill));
                 }
                 break;
+            }
 
             default:
                 super.renderSingleItem(item, option, index);
@@ -1219,7 +1246,9 @@ export class TagEditContextMenu extends DynamicContextMenu {
     createPill(tagOrTrigger, isTrigger) {
         const pillEl = document.createElement('span');
         let displayName, pillFill;
-        pillEl.style.cssText = `padding: 2.5px 7.5px; border-radius: 5px; font-size: 11px; color: white; display: inline-block; max-width: 100%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; vertical-align: middle; line-height: 1.5;`;
+        // flex: 0 1 auto + min-width: 0 - as flex items the pills default to min-width: auto,
+        // which keeps a long name from shrinking and pushes it out of the panel instead.
+        pillEl.style.cssText = `padding: 2.5px 7.5px; border-radius: 5px; font-size: 11px; color: white; display: inline-block; flex: 0 1 auto; min-width: 0; max-width: 100%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; vertical-align: middle; line-height: 1.5;`;
         
         if (isTrigger) {
             displayName = tagOrTrigger;

--- a/web/js/pills.js
+++ b/web/js/pills.js
@@ -1,3 +1,5 @@
+import { app } from "../../../../scripts/app.js";
+
 // DOM rendering of the tag pill area.
 //
 // The canvas path (onDrawForeground + node.onMouseDown + the processContextMenu patch)
@@ -26,7 +28,11 @@ function injectStyles() {
             display: block;
             box-sizing: border-box;
             width: 100%;
-            overflow: hidden;
+            min-height: 0;
+            /* Shrinking the node past its tags scrolls them instead of clipping */
+            overflow-x: hidden;
+            overflow-y: auto;
+            scrollbar-width: thin;
         }
         .erenodes-pills {
             display: flex;
@@ -219,6 +225,9 @@ const KNOB_DEFAULT = "#8899bb";
 
 const IMAGE_TYPES = ["lora", "embedding", "group"];
 
+// One pill row - the smallest the tag area may be squeezed to before it just scrolls.
+const MIN_AREA_HEIGHT = 20;
+
 const parseTags = value => {
     try {
         const parsed = JSON.parse(value || "[]");
@@ -324,7 +333,9 @@ export function attachTagPillWidget(node, config = {}) {
         hideOnZoom: false,
         serialize: false,
         margin: 6,
-        getMinHeight: () => naturalHeight(),
+        // The floor is what lets the node be dragged smaller than its tags: the layout
+        // hands the widget whatever is left, and the area scrolls the rest.
+        getMinHeight: () => Math.min(naturalHeight(), MIN_AREA_HEIGHT + widget.margin * 2),
         getMaxHeight: () => naturalHeight()
     });
     widget.serialize = false;
@@ -353,20 +364,63 @@ export function attachTagPillWidget(node, config = {}) {
     // The legacy renderer sizes nodes from litegraph's layout, so the node has to be
     // grown to fit the pills. Vue nodes measure the DOM themselves - touching setSize
     // there fights their ResizeObserver.
+    let applyingAutoHeight = false;
+
     function syncNodeHeight() {
         if (!autoHeight || LiteGraph.vueNodesMode) return;
         if (!root.isConnected || !node.graph) return;
         // Collapsed or not laid out yet - measuring now would resize the node to nothing.
         if (node.flags?.collapsed || !content.offsetHeight) return;
+        // The height is the user's now; the area scrolls instead of pushing the node.
+        if (node.properties?._tagAreaManualHeight) return;
 
         const target = Math.round((widget.y ?? 30) + naturalHeight() + heightBelow() + 4);
-        node._erePillsHeight = target;
 
         if (Math.abs(node.size[1] - target) > 1) {
-            node.setSize([node.size[0], target]);
+            applyingAutoHeight = true;
+            try {
+                node.setSize([node.size[0], target]);
+            } finally {
+                applyingAutoHeight = false;
+            }
             node.setDirtyCanvas(true, true);
         }
     }
+
+    // A manual resize hands the height over to the user for good - stored on the node so
+    // it survives a reload. Gated on the canvas actually dragging this node's handle:
+    // the layout grows nodes with setSize() too, and that must not count as manual.
+    const origResize = node.onResize;
+    node.onResize = function (...args) {
+        const draggedByUser = app.canvas?.resizing_node === node;
+        if (draggedByUser && !applyingAutoHeight && autoHeight && !LiteGraph.vueNodesMode) {
+            node.properties = node.properties || {};
+            node.properties._tagAreaManualHeight = true;
+        }
+        return origResize?.apply(this, args);
+    };
+
+    // Give the wheel back to the canvas when there is nothing to scroll, so zooming over
+    // the node keeps working.
+    root.addEventListener("wheel", e => {
+        const scrollable = root.scrollHeight > root.clientHeight + 1;
+        const atTop = root.scrollTop <= 0 && e.deltaY < 0;
+        const atBottom = root.scrollTop + root.clientHeight >= root.scrollHeight - 1 && e.deltaY > 0;
+
+        if (scrollable && !atTop && !atBottom) {
+            e.stopPropagation();
+            return;
+        }
+
+        e.preventDefault();
+        app.canvas?.processMouseWheel?.(e);
+    }, { passive: false });
+
+    // Lets the node be snapped back to its content after a manual resize.
+    node.onFitTagArea = () => {
+        if (node.properties) delete node.properties._tagAreaManualHeight;
+        syncNodeHeight();
+    };
 
     function pillTarget(label, button = false) {
         return { label, button };

--- a/web/js/pills.js
+++ b/web/js/pills.js
@@ -361,18 +361,56 @@ export function attachTagPillWidget(node, config = {}) {
         return total;
     }
 
+    const scrollEnabled = () => app.ui?.settings?.getSettingValue?.("EreNodes.Nodes.TagAreaScroll", true) ?? true;
+
+    // Height the node has left for the tag area, both renderers - arrange() keeps
+    // widget.y and computedHeight up to date even when Vue draws the node.
+    function availableHeight() {
+        return node.size[1] - (widget.y ?? 30) - heightBelow() - widget.margin * 2 - 4;
+    }
+
     // The legacy renderer sizes nodes from litegraph's layout, so the node has to be
     // grown to fit the pills. Vue nodes measure the DOM themselves - touching setSize
-    // there fights their ResizeObserver.
+    // there fights their ResizeObserver, so there the area is capped with max-height
+    // instead and the node stops growing on its own.
     let applyingAutoHeight = false;
+    // Vue nodes shrink back to the DOM asynchronously, so a fit request suspends the cap
+    // for a moment instead of re-applying it before the node has grown.
+    let fitUntil = 0;
 
-    function syncNodeHeight() {
-        if (!autoHeight || LiteGraph.vueNodesMode) return;
+    function setStyle(prop, value) {
+        if (root.style[prop] !== value) root.style[prop] = value;
+    }
+
+    function applyHeightPolicy() {
+        if (!autoHeight) return;
         if (!root.isConnected || !node.graph) return;
         // Collapsed or not laid out yet - measuring now would resize the node to nothing.
         if (node.flags?.collapsed || !content.offsetHeight) return;
+
+        const scrolls = scrollEnabled();
+        // Only write when it actually changes: every style write resizes the element and
+        // comes straight back through the ResizeObserver.
+        setStyle("overflowY", scrolls ? "auto" : "hidden");
+
+        if (LiteGraph.vueNodesMode) {
+            const available = availableHeight();
+            // Only cap once the node is actually smaller than its tags, otherwise a
+            // freshly placed node would scroll instead of growing to fit. After a fit
+            // request the cap is held off until the node has caught up with the content.
+            const fitting = performance.now() < fitUntil;
+            const shrunk = scrolls && !fitting && available > MIN_AREA_HEIGHT && available < content.offsetHeight - 2;
+
+            setStyle("maxHeight", shrunk ? `${Math.round(available)}px` : "");
+            node._tagAreaCapped = shrunk;
+            return;
+        }
+
+        setStyle("maxHeight", "");
+        node._tagAreaCapped = scrolls && !!node.properties?._tagAreaManualHeight;
+
         // The height is the user's now; the area scrolls instead of pushing the node.
-        if (node.properties?._tagAreaManualHeight) return;
+        if (scrolls && node.properties?._tagAreaManualHeight) return;
 
         const target = Math.round((widget.y ?? 30) + naturalHeight() + heightBelow() + 4);
 
@@ -387,6 +425,11 @@ export function attachTagPillWidget(node, config = {}) {
         }
     }
 
+    // Kept as the name the rest of the module calls.
+
+
+    node.onTagAreaPolicyChanged = () => applyHeightPolicy();
+
     // A manual resize hands the height over to the user for good - stored on the node so
     // it survives a reload. Gated on the canvas actually dragging this node's handle:
     // the layout grows nodes with setSize() too, and that must not count as manual.
@@ -397,6 +440,13 @@ export function attachTagPillWidget(node, config = {}) {
             node.properties = node.properties || {};
             node.properties._tagAreaManualHeight = true;
         }
+
+        // Vue nodes: the cap is derived from the node's own height, so it has to follow
+        // every resize.
+        if (LiteGraph.vueNodesMode && !applyingAutoHeight) {
+            applyHeightPolicy();
+        }
+
         return origResize?.apply(this, args);
     };
 
@@ -419,7 +469,10 @@ export function attachTagPillWidget(node, config = {}) {
     // Lets the node be snapped back to its content after a manual resize.
     node.onFitTagArea = () => {
         if (node.properties) delete node.properties._tagAreaManualHeight;
-        syncNodeHeight();
+        fitUntil = performance.now() + 300;
+        root.style.maxHeight = "";
+        node._tagAreaCapped = false;
+        applyHeightPolicy();
     };
 
     function pillTarget(label, button = false) {
@@ -590,7 +643,7 @@ export function attachTagPillWidget(node, config = {}) {
         }
 
         content.replaceChildren(...children);
-        syncNodeHeight();
+        applyHeightPolicy();
     }
 
     // Every tag mutation funnels through onUpdateTextWidget, so chain the re-render onto it.
@@ -601,9 +654,12 @@ export function attachTagPillWidget(node, config = {}) {
         return result;
     };
 
-    // Node width changes reflow the pills, which can change the height.
-    const observer = new ResizeObserver(() => syncNodeHeight());
+    // Content: width changes reflow the pills, which changes the height they need.
+    // Root: Vue nodes apply a resize straight to the DOM, so this is what tells us the
+    // node got smaller and the area has to be capped.
+    const observer = new ResizeObserver(() => applyHeightPolicy());
     observer.observe(content);
+    observer.observe(root);
 
     const origRemoved = node.onRemoved;
     node.onRemoved = function (...args) {

--- a/web/js/pills.js
+++ b/web/js/pills.js
@@ -1,0 +1,567 @@
+// DOM rendering of the tag pill area.
+//
+// The canvas path (onDrawForeground + node.onMouseDown + the processContextMenu patch)
+// only exists in the legacy renderer: with Vue nodes enabled LGraphCanvas.drawNode()
+// returns before any node body drawing and pointer events go to Vue components instead.
+// A DOM widget renders in both - the legacy renderer mounts it in the DomWidgets overlay
+// positioned from the litegraph layout, Vue nodes mount the same element inside the node
+// through WidgetDOM.vue - so this module is the single implementation for both modes.
+//
+// Variants:
+//   toggle  - full width rows with a switch (Toggle)
+//   chips   - inline wrapped chips (Cloud, MultiSelect, Randomizer)
+//   gallery - image cards with a name bar (Gallery)
+//   buttons - button row only, no tags (Multiline)
+
+const STYLE_ID = "erenodes-pill-widget-styles";
+
+function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+        /* The renderers stretch the mounted element (h-full / flex-1), so the content
+           lives in an inner box whose height can be measured without feedback. */
+        .erenodes-pills-root {
+            display: block;
+            box-sizing: border-box;
+            width: 100%;
+            overflow: hidden;
+        }
+        .erenodes-pills {
+            display: flex;
+            flex-wrap: wrap;
+            align-content: flex-start;
+            gap: 5px;
+            box-sizing: border-box;
+            width: 100%;
+            height: fit-content;
+            font: 12px monospace;
+            color: var(--ere-text, #ddd);
+        }
+        .erenodes-pills[data-framed="true"] {
+            padding: 5px;
+            border: 1px solid #444;
+            border-radius: 5px;
+            background: var(--ere-widget-bg, #222);
+        }
+        /* Themed like the frontend's own node widgets: the litegraph constants are a
+           flat grey box with near-white text, which stands out against the node. The
+           --component-node-* variables are declared on :root / .dark-theme, so they
+           reach the widget in both renderers; litegraph values stay as the fallback. */
+        .erenodes-pill-button {
+            flex: 0 0 auto;
+            width: 20px;
+            height: 20px;
+            padding: 0;
+            border: 1px solid var(--component-node-border, #444);
+            border-radius: 5px;
+            background: var(--component-node-widget-background, var(--ere-box, #353535));
+            color: var(--component-node-foreground-secondary, var(--ere-text, #aaa));
+            font: inherit;
+            line-height: 18px;
+            text-align: center;
+            cursor: pointer;
+        }
+        .erenodes-pill-button:hover {
+            background: var(--component-node-widget-background-hovered, var(--ere-widget-bg, #2a2a2a));
+            color: var(--component-node-foreground, var(--ere-text, #ddd));
+        }
+        /* Cards are much taller than buttons, so they get a row of their own. */
+        .erenodes-pills-buttons {
+            flex: 1 0 100%;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+        }
+        .erenodes-pill {
+            display: flex;
+            align-items: center;
+            box-sizing: border-box;
+            height: 20px;
+            border-radius: 5px;
+            cursor: pointer;
+            user-select: none;
+        }
+        .erenodes-pill:hover { filter: brightness(1.2); }
+        .erenodes-pill-name {
+            flex: 1 1 auto;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .erenodes-pill-strength {
+            flex: 0 0 auto;
+            margin-left: 4px;
+            opacity: 0.5;
+        }
+
+        /* toggle variant */
+        .erenodes-pills[data-variant="toggle"] .erenodes-pill {
+            flex: 1 0 100%;
+            gap: 7px;
+            padding: 0 7px 0 5px;
+            border: 1px solid #444;
+            background: var(--ere-widget-bg, #222);
+        }
+        .erenodes-pills[data-variant="toggle"] .erenodes-pill[data-active="false"] { opacity: 0.75; }
+        .erenodes-pill-switch {
+            flex: 0 0 auto;
+            position: relative;
+            width: 18px;
+            height: 14px;
+            border-radius: 5px;
+            background: #3b3b3b;
+        }
+        .erenodes-pill-knob {
+            position: absolute;
+            top: 50%;
+            left: -3px;
+            width: 14px;
+            height: 14px;
+            margin-top: -7px;
+            border-radius: 50%;
+            background: #888;
+            transition: left 0.1s ease;
+        }
+        .erenodes-pill[data-active="true"] .erenodes-pill-knob {
+            left: 7px;
+            background: var(--ere-accent, #8899bb);
+        }
+
+        /* chips variant */
+        .erenodes-pills[data-variant="chips"] .erenodes-pill {
+            max-width: 100%;
+            padding: 0 5px;
+            border: 1px solid var(--ere-accent, #414650);
+            background: var(--ere-accent, #414650);
+            color: #fff;
+        }
+        .erenodes-pills[data-variant="chips"] .erenodes-pill[data-active="false"] {
+            border-color: #444;
+            background: var(--ere-widget-bg, #222);
+            color: var(--ere-text, #ddd);
+            opacity: 0.75;
+        }
+
+        /* gallery variant */
+        .erenodes-pills[data-variant="gallery"] .erenodes-pill {
+            position: relative;
+            display: block;
+            height: auto;
+            padding: 0;
+            overflow: hidden;
+            border: 1px solid #444;
+            background: #222;
+        }
+        .erenodes-card-image {
+            display: block;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+        .erenodes-pill[data-active="false"] .erenodes-card-image {
+            filter: grayscale(0.75);
+            opacity: 0.25;
+        }
+        .erenodes-card-name {
+            position: absolute;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            height: 20px;
+            padding: 0 5px;
+            box-sizing: border-box;
+            line-height: 20px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            background: var(--ere-accent, #414650);
+            color: #fff;
+        }
+        .erenodes-pill[data-active="false"] .erenodes-card-name {
+            background: var(--ere-widget-bg, #222);
+            color: var(--ere-text, #ddd);
+            opacity: 0.5;
+        }
+        .erenodes-card-info {
+            position: absolute;
+            top: 2.5px;
+            right: 2.5px;
+            padding: 0 2.5px;
+            border-radius: 5px;
+            background: #222;
+            color: #fff;
+            font-size: 10px;
+            line-height: 15px;
+            opacity: 0.75;
+        }
+        .erenodes-pill[data-active="false"] .erenodes-card-info { opacity: 0.5; }
+    `;
+    document.head.appendChild(style);
+}
+
+// Pill accent per tag type, matching the canvas renderer.
+const CHIP_COLORS = {
+    lora: "#415041",
+    embedding: "#504149",
+    group: "#504C41"
+};
+const CHIP_DEFAULT = "#414650";
+
+const KNOB_COLORS = {
+    lora: "#89a189",
+    embedding: "#9b8899",
+    group: "#9b9188"
+};
+const KNOB_DEFAULT = "#8899bb";
+
+const IMAGE_TYPES = ["lora", "embedding", "group"];
+
+const parseTags = value => {
+    try {
+        const parsed = JSON.parse(value || "[]");
+        if (Array.isArray(parsed)) return parsed;
+    } catch {}
+    return [];
+};
+
+// Same display rules the canvas renderer used: strip the extension from file-backed
+// tags, drop the embedding: prefix, and append the trigger count for loras.
+function getDisplayName(tag, { withTriggers = true } = {}) {
+    let displayName = tag.name ?? "";
+
+    if (tag.type === "lora") {
+        const dotIndex = displayName.lastIndexOf(".");
+        if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
+        if (withTriggers && tag.triggers?.length > 0) displayName += ` [+${tag.triggers.length}]`;
+    } else if (tag.type === "embedding") {
+        displayName = displayName.replace(/^embedding:/, "");
+    } else if (tag.type === "group") {
+        const dotIndex = displayName.lastIndexOf(".");
+        if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
+    }
+
+    return displayName;
+}
+
+/**
+ * Dropdown of the node's inactive tags, opened by clicking the empty area of the
+ * pill container (MultiSelect / Randomizer).
+ */
+export function openInactiveTagsMenu(node, event) {
+    const tagData = parseTags(node.properties?._tagDataJSON || "[]");
+    const options = tagData
+        .filter(tag => !tag.active && tag.name)
+        .map(tag => ({
+            content: tag.name,
+            callback: () => {
+                const entry = tagData.find(t => t.name === tag.name);
+                if (entry) entry.active = true;
+                node.properties._tagDataJSON = JSON.stringify(tagData, null, 2);
+                node.onUpdateTextWidget(node);
+            }
+        }));
+
+    if (options.length > 0) {
+        new LiteGraph.ContextMenu(options, { event, className: "dark" }, window);
+    }
+}
+
+/**
+ * Renders the node's tag pills as a DOM widget and wires clicks to the shared
+ * node.onTagPillClick / node.onTagQuickEdit handlers.
+ *
+ * @param {object} node    the litegraph node
+ * @param {object} config
+ *   variant            "toggle" | "chips" | "gallery" | "buttons"
+ *   buttons            [{ label, display, title }]
+ *   showInactive       render inactive tags too (default true)
+ *   framed             draw a container box around the area (default false)
+ *   autoHeight         grow the node to fit the content, legacy renderer (default true)
+ *   onBackgroundClick  handler for clicks on the empty area
+ *   getCardSize        () => [w, h], gallery variant only
+ * @returns the created DOM widget
+ */
+export function attachTagPillWidget(node, config = {}) {
+    injectStyles();
+
+    const {
+        variant = "chips",
+        buttons = [],
+        showInactive = true,
+        framed = false,
+        autoHeight = true,
+        onBackgroundClick,
+        getCardSize
+    } = config;
+
+    const root = document.createElement("div");
+    root.className = "erenodes-pills-root";
+
+    const content = document.createElement("div");
+    content.className = "erenodes-pills";
+    content.dataset.variant = variant;
+    if (framed) content.dataset.framed = "true";
+    root.appendChild(content);
+
+    // Pointer events on the pills are ours - don't let them reach the canvas
+    // (node dragging in the legacy renderer, node selection in Vue nodes).
+    for (const type of ["pointerdown", "pointermove", "pointerup"]) {
+        root.addEventListener(type, e => e.stopPropagation());
+    }
+
+    if (onBackgroundClick) {
+        content.addEventListener("click", e => {
+            if (e.target !== content) return;
+            e.preventDefault();
+            onBackgroundClick(e);
+        });
+    }
+
+    const widget = node.addDOMWidget("erenodes_pills", "erenodes_pills", root, {
+        hideOnZoom: false,
+        serialize: false,
+        margin: 6,
+        getMinHeight: () => naturalHeight(),
+        getMaxHeight: () => naturalHeight()
+    });
+    widget.serialize = false;
+
+    // Height the widget box needs, margins included (the overlay insets the element
+    // by `margin` on each side). Measured on the inner box - the outer one is stretched
+    // to the allocated height, so measuring it would feed its own size back in.
+    function naturalHeight() {
+        return Math.max(content.offsetHeight, 20) + widget.margin * 2;
+    }
+
+    // Widgets placed after this one (e.g. the Randomizer's control) still need room.
+    function heightBelow() {
+        const widgets = node.widgets ?? [];
+        const index = widgets.indexOf(widget);
+        if (index === -1) return 0;
+
+        let total = 0;
+        for (const w of widgets.slice(index + 1)) {
+            if (w.hidden) continue;
+            total += w.computedHeight ?? (LiteGraph.NODE_WIDGET_HEIGHT + 4);
+        }
+        return total;
+    }
+
+    // The legacy renderer sizes nodes from litegraph's layout, so the node has to be
+    // grown to fit the pills. Vue nodes measure the DOM themselves - touching setSize
+    // there fights their ResizeObserver.
+    function syncNodeHeight() {
+        if (!autoHeight || LiteGraph.vueNodesMode) return;
+        if (!root.isConnected || !node.graph) return;
+        // Collapsed or not laid out yet - measuring now would resize the node to nothing.
+        if (node.flags?.collapsed || !content.offsetHeight) return;
+
+        const target = Math.round((widget.y ?? 30) + naturalHeight() + heightBelow() + 4);
+        node._erePillsHeight = target;
+
+        if (Math.abs(node.size[1] - target) > 1) {
+            node.setSize([node.size[0], target]);
+            node.setDirtyCanvas(true, true);
+        }
+    }
+
+    function pillTarget(label, button = false) {
+        return { label, button };
+    }
+
+    function makeButton({ label, display, title }) {
+        const el = document.createElement("button");
+        el.type = "button";
+        el.className = "erenodes-pill-button";
+        el.textContent = display;
+        if (title) el.title = title;
+
+        // Not stopped on purpose: the click has to reach the widget root, where the
+        // renderer's selectOn handler selects and raises the node.
+        el.addEventListener("click", e => {
+            e.preventDefault();
+            node.onTagPillClick?.(e, [0, 0], pillTarget(label, true));
+        });
+
+        return el;
+    }
+
+    function bindPillEvents(el, tag) {
+        el.addEventListener("click", e => {
+            e.preventDefault();
+            node.onTagPillClick?.(e, [0, 0], pillTarget(tag.name));
+        });
+
+        // Quick edit. TagEditContextMenu positions itself from clientX/clientY, so anchor
+        // it to the pill the same way the canvas patch anchored it to the drawn pill.
+        el.addEventListener("contextmenu", e => {
+            e.preventDefault();
+            e.stopPropagation();
+
+            const rect = el.getBoundingClientRect();
+            const positionEvent = { clientX: rect.left, clientY: rect.bottom + 5 };
+            // The menu caps its width to the node's on-screen width; the widget spans it.
+            const nodeScreenWidth = root.getBoundingClientRect().width;
+            node.onTagQuickEdit?.(positionEvent, node, pillTarget(tag.name), nodeScreenWidth);
+        });
+    }
+
+    function makeStrength(tag) {
+        if (!tag.strength || Number(tag.strength) === 1.0) return null;
+        const strength = document.createElement("span");
+        strength.className = "erenodes-pill-strength";
+        strength.textContent = Number(tag.strength).toFixed(2);
+        return strength;
+    }
+
+    function makeBasePill(tag, accent) {
+        const el = document.createElement("div");
+        el.className = "erenodes-pill";
+        el.dataset.active = String(!!tag.active);
+        if (tag.type) el.dataset.type = tag.type;
+        el.style.setProperty("--ere-accent", accent);
+        bindPillEvents(el, tag);
+        return el;
+    }
+
+    function makeTogglePill(tag) {
+        const el = makeBasePill(tag, KNOB_COLORS[tag.type] ?? KNOB_DEFAULT);
+
+        const track = document.createElement("span");
+        track.className = "erenodes-pill-switch";
+        const knob = document.createElement("span");
+        knob.className = "erenodes-pill-knob";
+        track.appendChild(knob);
+
+        const name = document.createElement("span");
+        name.className = "erenodes-pill-name";
+        name.textContent = getDisplayName(tag);
+        name.title = tag.name ?? "";
+
+        el.append(track, name);
+
+        const strength = makeStrength(tag);
+        if (strength) el.appendChild(strength);
+
+        return el;
+    }
+
+    function makeChipPill(tag) {
+        const el = makeBasePill(tag, CHIP_COLORS[tag.type] ?? CHIP_DEFAULT);
+
+        const name = document.createElement("span");
+        name.className = "erenodes-pill-name";
+        name.textContent = getDisplayName(tag);
+        name.title = tag.name ?? "";
+        el.appendChild(name);
+
+        const strength = makeStrength(tag);
+        if (strength) el.appendChild(strength);
+
+        return el;
+    }
+
+    function makeGalleryPill(tag) {
+        const [cardWidth, cardHeight] = getCardSize?.() ?? [100, 100];
+
+        const el = makeBasePill(tag, CHIP_COLORS[tag.type] ?? CHIP_DEFAULT);
+        el.style.width = `${cardWidth}px`;
+        el.style.height = `${cardHeight}px`;
+
+        if (IMAGE_TYPES.includes(tag.type)) {
+            const image = document.createElement("img");
+            image.className = "erenodes-card-image";
+            image.loading = "lazy";
+            image.draggable = false;
+            image.src = `/erenodes/view/${tag.type}/${encodeURIComponent(tag.name)}?w=${cardWidth}&h=${cardHeight}&fit=cover`;
+            // Tags without an image just keep the plain card background.
+            image.addEventListener("error", () => image.remove());
+            el.appendChild(image);
+        }
+
+        const info = [];
+        if (tag.triggers?.length > 0) info.push(`[+${tag.triggers.length}]`);
+        if (tag.strength && Number(tag.strength) !== 1.0) info.push(Number(tag.strength).toFixed(2));
+
+        if (info.length) {
+            const infoEl = document.createElement("span");
+            infoEl.className = "erenodes-card-info";
+            infoEl.textContent = info.join(" ");
+            el.appendChild(infoEl);
+        }
+
+        const name = document.createElement("span");
+        name.className = "erenodes-card-name";
+        name.textContent = getDisplayName(tag, { withTriggers: false });
+        name.title = tag.name ?? "";
+        el.appendChild(name);
+
+        return el;
+    }
+
+    const PILL_BUILDERS = {
+        toggle: makeTogglePill,
+        chips: makeChipPill,
+        gallery: makeGalleryPill
+    };
+
+    function render() {
+        content.style.setProperty("--ere-text", LiteGraph.WIDGET_TEXT_COLOR);
+        content.style.setProperty("--ere-widget-bg", LiteGraph.WIDGET_BGCOLOR);
+        content.style.setProperty("--ere-box", LiteGraph.NODE_DEFAULT_BOXCOLOR);
+
+        const buttonElements = buttons.map(makeButton);
+        const children = [];
+
+        if (variant === "gallery" && buttonElements.length) {
+            const row = document.createElement("div");
+            row.className = "erenodes-pills-buttons";
+            row.append(...buttonElements);
+            children.push(row);
+        } else {
+            children.push(...buttonElements);
+        }
+
+        const buildPill = PILL_BUILDERS[variant];
+
+        if (buildPill) {
+            for (const tag of parseTags(node.properties?._tagDataJSON || "[]")) {
+                if (!tag?.name) continue;
+                if (!showInactive && !tag.active) continue;
+                children.push(buildPill(tag));
+            }
+        }
+
+        content.replaceChildren(...children);
+        syncNodeHeight();
+    }
+
+    // Every tag mutation funnels through onUpdateTextWidget, so chain the re-render onto it.
+    const origUpdate = node.onUpdateTextWidget;
+    node.onUpdateTextWidget = async function (...args) {
+        const result = await origUpdate?.apply(this, args);
+        render();
+        return result;
+    };
+
+    // Node width changes reflow the pills, which can change the height.
+    const observer = new ResizeObserver(() => syncNodeHeight());
+    observer.observe(content);
+
+    const origRemoved = node.onRemoved;
+    node.onRemoved = function (...args) {
+        observer.disconnect();
+        return origRemoved?.apply(this, args);
+    };
+
+    node._erePillWidget = widget;
+    node._erePillRender = render;
+    render();
+
+    return widget;
+}
+
+export { parseTags, getDisplayName };

--- a/web/js/settings.js
+++ b/web/js/settings.js
@@ -55,6 +55,24 @@ app.registerExtension({
         });
 
         app.ui.settings.addSetting({
+            id: "EreNodes.Nodes.TagAreaScroll",
+            name: "Scrollable Tag Area",
+            tooltip: "Resizing a node smaller than its tags scrolls them. Turn off to always grow the node to fit.",
+            type: "boolean",
+            defaultValue: true,
+            onChange: (newVal) => {
+                fetch("/erenodes/set_setting", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ key: "node.tag_area_scroll", value: newVal }),
+                });
+
+                for (const node of app.graph?._nodes ?? []) node.onTagAreaPolicyChanged?.();
+                app.graph?.setDirtyCanvas(true, true);
+            },
+        });
+
+        app.ui.settings.addSetting({
             id: "EreNodes.Nodes.PasteAction",
             name: "Paste Action",
             type: "combo",

--- a/web/js/settings.js
+++ b/web/js/settings.js
@@ -25,6 +25,21 @@ app.registerExtension({
         });
 
         app.ui.settings.addSetting({
+            id: "EreNodes.Autocomplete.Nodes",
+            name: "Autocomplete in EreNodes prompts",
+            tooltip: "Keep autocomplete inside EreNodes prompt nodes even when Global Autocomplete is off.",
+            type: "boolean",
+            defaultValue: true,
+            onChange: (newVal) => {
+                fetch("/erenodes/set_setting", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ key: "autocomplete.nodes", value: newVal }),
+                });
+            },
+        });
+
+        app.ui.settings.addSetting({
             id: "EreNodes.Autocomplete.CSV",
             name: "Autocomplete CSV File",
             type: "combo",

--- a/web/prompt.js
+++ b/web/prompt.js
@@ -325,8 +325,8 @@ export function initializeSharedPromptFunctions(node, textWidget) {
             { content: "Replace Tags from Clipboard", callback: () => node.onClipboardReplace?.() },
             { content: "Add Tags from Clipboard", callback: () => node.onClipboardAppend?.() },
             null,
-            // Only offered once a manual resize has taken the height over
-            ...(node.properties?._tagAreaManualHeight
+            // Only offered while the tag area is actually capped
+            ...(node._tagAreaCapped
                 ? [{ content: "Fit Height to Tags", callback: () => node.onFitTagArea?.() }]
                 : []),
             { content: "Toggle All Tags", callback: () => node.onToggleTags?.() },

--- a/web/prompt.js
+++ b/web/prompt.js
@@ -324,7 +324,11 @@ export function initializeSharedPromptFunctions(node, textWidget) {
         let options = [
             { content: "Replace Tags from Clipboard", callback: () => node.onClipboardReplace?.() },
             { content: "Add Tags from Clipboard", callback: () => node.onClipboardAppend?.() },
-            null, 
+            null,
+            // Only offered once a manual resize has taken the height over
+            ...(node.properties?._tagAreaManualHeight
+                ? [{ content: "Fit Height to Tags", callback: () => node.onFitTagArea?.() }]
+                : []),
             { content: "Toggle All Tags", callback: () => node.onToggleTags?.() },
             { content: "Remove All Tags", callback: () => node.onRemoveTags?.() },
             { content: "Remove Inactive Tags", callback: () => node.onRemoveTags?.('inactive') },

--- a/web/prompt.js
+++ b/web/prompt.js
@@ -214,6 +214,42 @@ export function applyContextMenuPatch() {
     };
 }
 
+// Reserves vertical space in the node's widget layout for the canvas-drawn pill area.
+// Hidden widgets are excluded from the layout (LGraphNode.getLayoutWidgets filters on
+// `hidden`), so the old trick of sizing a hidden widget no longer holds any space and
+// the following widgets / DOM textarea draw on top of the pills. This spacer stays
+// visible to the layout but draws nothing, is never serialized, and is marked disabled
+// so pointer hits fall through to node.onMouseDown instead of being swallowed by it.
+export function addLayoutSpacer(node, name, height = 0, index = null) {
+    node.widgets = node.widgets || [];
+
+    const spacer = {
+        name,
+        type: "custom",
+        value: "",
+        serialize: false,                 // keeps it out of workflow widgets_values
+        options: { serialize: false },    // keeps it out of the queued prompt
+        disabled: true,                   // -> computedDisabled, so getWidgetOnPos skips it
+        computedDisabled: true,
+        spacerHeight: height,
+        computeSize() { return [0, this.spacerHeight]; },
+        draw() {}
+    };
+
+    if (index === null || index >= node.widgets.length) {
+        node.widgets.push(spacer);
+    } else {
+        node.widgets.splice(Math.max(0, index), 0, spacer);
+    }
+
+    return spacer;
+}
+
+// Top of a spacer's reserved area, falling back to `fallbackY` before the first arrange().
+export function getSpacerTop(spacer, fallbackY) {
+    return typeof spacer?.y === "number" ? spacer.y : fallbackY;
+}
+
 export function initializeSharedPromptFunctions(node, textWidget) {
 
     node.properties = node.properties || {};

--- a/web/prompt.js
+++ b/web/prompt.js
@@ -214,42 +214,6 @@ export function applyContextMenuPatch() {
     };
 }
 
-// Reserves vertical space in the node's widget layout for the canvas-drawn pill area.
-// Hidden widgets are excluded from the layout (LGraphNode.getLayoutWidgets filters on
-// `hidden`), so the old trick of sizing a hidden widget no longer holds any space and
-// the following widgets / DOM textarea draw on top of the pills. This spacer stays
-// visible to the layout but draws nothing, is never serialized, and is marked disabled
-// so pointer hits fall through to node.onMouseDown instead of being swallowed by it.
-export function addLayoutSpacer(node, name, height = 0, index = null) {
-    node.widgets = node.widgets || [];
-
-    const spacer = {
-        name,
-        type: "custom",
-        value: "",
-        serialize: false,                 // keeps it out of workflow widgets_values
-        options: { serialize: false },    // keeps it out of the queued prompt
-        disabled: true,                   // -> computedDisabled, so getWidgetOnPos skips it
-        computedDisabled: true,
-        spacerHeight: height,
-        computeSize() { return [0, this.spacerHeight]; },
-        draw() {}
-    };
-
-    if (index === null || index >= node.widgets.length) {
-        node.widgets.push(spacer);
-    } else {
-        node.widgets.splice(Math.max(0, index), 0, spacer);
-    }
-
-    return spacer;
-}
-
-// Top of a spacer's reserved area, falling back to `fallbackY` before the first arrange().
-export function getSpacerTop(spacer, fallbackY) {
-    return typeof spacer?.y === "number" ? spacer.y : fallbackY;
-}
-
 export function initializeSharedPromptFunctions(node, textWidget) {
 
     node.properties = node.properties || {};
@@ -280,6 +244,7 @@ export function initializeSharedPromptFunctions(node, textWidget) {
         }
 
         if (name === "_tagImageWidth" || name === "_tagImageHeight") {
+            this._erePillRender?.();
             this.setDirtyCanvas(true, true);
         }
 

--- a/web/prompt_autocomplete.js
+++ b/web/prompt_autocomplete.js
@@ -466,9 +466,22 @@ class GlobalAutocomplete {
             };
         }
 
-        this.menu.root.style.left = `${finalCoords.x}px`;
-        this.menu.root.style.top = `${finalCoords.bottom}px`;
-        this.menu.root.style.maxHeight = (window.innerHeight - finalCoords.bottom) + "px";
+        const spaceBelow = window.innerHeight - finalCoords.bottom;
+        const spaceAbove = finalCoords.y;
+
+        this.menu.root.style.left = `${Math.max(0, finalCoords.x)}px`;
+
+        // Entries are two lines tall, so a cramped strip below the cursor is unreadable;
+        // flip the menu above the current line when there's more room there.
+        if (spaceBelow < 160 && spaceAbove > spaceBelow) {
+            this.menu.root.style.top = "auto";
+            this.menu.root.style.bottom = `${window.innerHeight - finalCoords.y}px`;
+            this.menu.root.style.maxHeight = `${spaceAbove}px`;
+        } else {
+            this.menu.root.style.bottom = "auto";
+            this.menu.root.style.top = `${finalCoords.bottom}px`;
+            this.menu.root.style.maxHeight = `${spaceBelow}px`;
+        }
     }
 
     insertTag(selectedValue) {
@@ -541,7 +554,7 @@ if (typeof app !== "undefined") {
                 (!app.globalAutocompleteInstance.textarea || app.globalAutocompleteInstance.textarea !== e.target) // Only attach if not already attached or attached to a different element
             ) {
                 // Attach with default behavior for global textareas
-                app.globalAutocompleteInstance.attach(e.target, null, new Set(), e.target, "", triggerImmediately);
+                app.globalAutocompleteInstance.attach(e.target);
             }
         }
     });

--- a/web/prompt_autocomplete.js
+++ b/web/prompt_autocomplete.js
@@ -535,16 +535,44 @@ class GlobalAutocomplete {
     }
 }
 
+const ERE_NODE_TYPE_PREFIX = "ErePrompt";
+
+// Is this textarea the prompt input of one of our own nodes? Global autocomplete gets
+// turned off to stop it colliding with other extensions' autocomplete, but suggestions
+// are still expected inside the prompt nodes themselves.
+function isEreNodeTextarea(target) {
+    // Legacy renderer: the multiline input is a DOM widget, so the textarea is the
+    // widget's own element.
+    for (const node of app.graph?._nodes ?? []) {
+        if (!node.type?.startsWith(ERE_NODE_TYPE_PREFIX)) continue;
+        if (node.widgets?.some(w => w.element === target || w.inputEl === target)) return true;
+    }
+
+    // Vue nodes: the textarea belongs to a Vue component rather than to the widget, so
+    // go by the node element it sits in.
+    const nodeElement = target.closest?.("[data-node-id]");
+    if (nodeElement) {
+        const node = app.graph?.getNodeById?.(nodeElement.dataset.nodeId);
+        if (node?.type?.startsWith(ERE_NODE_TYPE_PREFIX)) return true;
+    }
+
+    return false;
+}
+
 // Initialize GlobalAutocomplete for general textareas
 // This needs to be done after the class definition.
 if (typeof app !== "undefined") {
     app.globalAutocompleteInstance = new GlobalAutocomplete(); // Store on app for access
     document.addEventListener("focusin", (e) => {
-        if (!app.ui.settings.getSettingValue('EreNodes.Autocomplete.Global', true)) {
-            return; // If the setting is disabled, do nothing.
-        }
-
         if (e.target.tagName === "TEXTAREA") {
+            const globalEnabled = app.ui.settings.getSettingValue('EreNodes.Autocomplete.Global', true);
+            const nodesEnabled = app.ui.settings.getSettingValue('EreNodes.Autocomplete.Nodes', true);
+
+            // Outside our own nodes the global setting still rules.
+            if (!globalEnabled && !(nodesEnabled && isEreNodeTextarea(e.target))) {
+                return;
+            }
+
             const parentContextMenu = e.target.closest('.litecontextmenu');
             const isSearchBoxParent = parentContextMenu ? parentContextMenu.querySelector('.comfy-context-menu-filter') : false;
 

--- a/web/prompt_cloud.js
+++ b/web/prompt_cloud.js
@@ -1,5 +1,6 @@
 import { app } from "../../scripts/app.js";
 import { initializeSharedPromptFunctions, applyContextMenuPatch } from "./prompt.js";
+import { attachTagPillWidget } from "./js/pills.js";
 
 app.registerExtension({
     name: "ErePromptCloud",
@@ -11,22 +12,6 @@ app.registerExtension({
     beforeRegisterNodeDef(nodeType, nodeData, app) {
         if (nodeData.name !== "ErePromptCloud") return;
 
-        // Shared layout constants
-        const pillX = 10, 
-              pillY = 30,
-              pillH = 20,
-              radius = 5,
-              spacing = 5, 
-              padding = 5;
-
-        const parseTags = value => {
-            try {
-                const parsed = JSON.parse(value || "[]");
-                if (Array.isArray(parsed)) return parsed;
-            } catch {}
-            return [];
-        };
-
         const origCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             if (origCreated) origCreated.apply(this, arguments);
@@ -35,194 +20,37 @@ app.registerExtension({
 
             const textWidget = node.widgets?.find(w => w.name === "text");
             textWidget.computeSize = () => [0, 0];
+            // `hidden` hides it in the legacy renderer, `options.hidden` in Vue nodes -
+            // they read different flags, and without the second one the raw tag JSON
+            // shows up as a textarea.
             textWidget.hidden = true;
-
-            node.onMouseDown = (e, pos) => {
-
-                const [x, y] = pos;
-
-                // Get background area
-                const bgX = 10, bgY = 35;
-                const bgW = node.size[0] - bgX * 2;
-                const bgH = node._tagAreaBottom - bgY;
-                if (x >= bgX && x <= bgX + bgW && y >= bgY && y <= bgY + bgH) {
-
-                    // Find if we are clicking pill
-                    let clickedPill = null;
-                    for (const pill of node._pillMap || []) {
-                        if (x >= pill.x && x <= pill.x + pill.w && y >= pill.y && y <= pill.y + pill.h) {
-                            clickedPill = pill;
-                            break;
-                        }
-                    }
-
-                    // Handle normal toggle click and quick edit shift click
-                    if (clickedPill) {
-                        node.onTagPillClick(e, pos, clickedPill);
-                    } 
-
-                }
-
-            };
+            textWidget.options = textWidget.options || {};
+            textWidget.options.hidden = true;
 
             // Initialize all other functions shared between prompt nodes
             initializeSharedPromptFunctions(this, textWidget);
+
+            // Tag pills are a DOM widget so they render in both the legacy and the
+            // Vue node renderer; clicks are wired to the shared handlers inside.
+            attachTagPillWidget(node, {
+                variant: "chips",
+                buttons: [
+                    { label: "button_menu", display: "≡", title: "Menu" },
+                    { label: "button_add_tag", display: "+", title: "Add tag" }
+                ]
+            });
+
             // Update on load
             this.onUpdateTextWidget(this);
-
         };
 
-        const origDraw = nodeType.prototype.onDrawForeground;
-        nodeType.prototype.onDrawForeground = function (ctx) {
-            if (origDraw) origDraw.call(this, ctx);
-
-            const textWidget = this.widgets?.find(w => w.name === "text");
-            if (!textWidget || this.flags?.collapsed) return;
-            
-            const tagData = parseTags(this.properties?._tagDataJSON || "[]");
-
-            ctx.font = "12px monospace";
-
-            const pillMaxWidth = this.size[0] - pillX * 2;
-            let currentX = pillX;
-            let currentY = pillY;
-
-            const positions = [];
-            const specialTags = [
-                { label: "button_menu", display: "≡" },
-                { label: "button_add_tag", display: "+" } // this button tag need to show at end after all tag pills
-            ];
-    
-            // Creating buttons
-            for (const { display, label } of specialTags) {
-                if (currentX + pillH > pillX + pillMaxWidth - padding) {
-                    currentX = pillX + padding;
-                    currentY += pillH + spacing;
-                }
-                positions.push({ x: currentX, y: currentY, w: 20, h: 20, label, display, button: true });
-                currentX += pillH + spacing;
-            }
-
-            // Creating pills
-            for (const tag of tagData) {
-
-                let label = tag.name;
-                let displayName = tag.name;
-                if (tag.type === 'lora') {
-                    // displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                    if (tag.triggers && tag.triggers.length > 0) {
-                        displayName += ` [+${tag.triggers.length}]`;
-                    }
-                } else if (tag.type === 'embedding') {
-                    displayName = displayName.replace(/^embedding:/, '');
-                } else if (tag.type === 'group') {
-                    // displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                }
-
-                let strengthText = "";
-                if (tag.strength && tag.strength !== 1.0) {
-                    tag.strength = tag.strength.toFixed(2);
-                    strengthText = ` ${tag.strength}`;
-                }
-
-                let display = displayName;
-                let strengthWidth = ctx.measureText(strengthText).width;
-                let textWidth = ctx.measureText(display).width + strengthWidth;
-            
-                // Trim and append ellipsis if too wide
-                let maxTextWidth = pillMaxWidth - padding * 2;
-                if (textWidth > pillMaxWidth - padding * 2) {
-                    let i = display.length;
-                    const dots = "…";
-                    const dotsWidth = ctx.measureText("…").width;
-                    while (i > 0 && ctx.measureText(display.slice(0, i)).width + dotsWidth + strengthWidth > maxTextWidth ) i--;
-                    display = display.slice(0, i) + dots;
-                }
-
-                // calculate pill width
-                const pillW = Math.min(textWidth + padding * 2, pillMaxWidth);
-            
-                if (currentX + pillW > pillX + pillMaxWidth) {
-                    currentX = pillX;
-                    currentY += pillH + spacing;
-                }
-            
-                positions.push({ x: currentX, y: currentY, w: pillW, h: pillH, label, display, active: !tag.active, type: tag.type, strength: tag.strength });
-                currentX += pillW + spacing;
-            }
-
-            // Store pill positions for click handling
-            this._pillMap = [];
-
-            for (const p of positions) {
-                ctx.beginPath();
-                ctx.globalAlpha = p.button ? 1 : (p.active ? 0.75 : 1);
-
-                let pillFill = "#414650"; // Default
-                if (p.type === 'lora') {
-                    pillFill = "#415041"; // Muted green-cyan
-                } else if (p.type === 'embedding') {
-                    pillFill = "#504149 "; // Muted yellow
-                } else if (p.type === 'group') {
-                    pillFill = "#504C41"; // Muted orange/brown
-                }
-                ctx.fillStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? LiteGraph.WIDGET_BGCOLOR : pillFill);
-                ctx.roundRect(p.x, p.y, p.w, p.h, 6);
-                ctx.fill();
-            
-                ctx.strokeStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? "#444" : pillFill);
-                ctx.lineWidth = 1;
-                ctx.stroke();
-
-                ctx.textBaseline = "middle";
-                const textX = p.x + (p.button ? p.w / 2 : padding);
-                const textY = p.y + p.h / 2 + 1;
-                
-                if(p.button) {
-                    ctx.textAlign = "center";
-                    ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-                    ctx.fillText(p.display, textX, textY);
-                } else {
-                    ctx.textAlign = "left";
-                    ctx.fillStyle = (p.active ? LiteGraph.WIDGET_TEXT_COLOR : "#FFF");
-                    ctx.fillText(p.display, textX, textY);
-
-                    if (p.strength && p.strength !== 1.0) {
-                        const nameWidth = ctx.measureText(p.display).width;
-                        const strengthText = ` ${p.strength}`;
-                        ctx.globalAlpha = 0.5;
-                        ctx.fillText(strengthText, textX + nameWidth, textY);
-                        ctx.globalAlpha = 1;
-                    }
-                }
-
-                ctx.textBaseline = "alphabetic";
-            
-                this._pillMap.push({ x: p.x, y: p.y, w: p.w, h: p.h, label: p.label, button: p.button });
-            }
-            
-            this._tagAreaBottom = currentY + pillH + padding;
-            this._measuredHeight = currentY + pillH + pillX;
-
-            // Height correction
-            if (isFinite(this._measuredHeight) && this._measuredHeight && this.size[1] !== this._measuredHeight) {
-                this.setSize([this.size[0], this._measuredHeight]);
-				this.setDirtyCanvas(true, true);
-            }
-
-        };
-        
-        const origResize = nodeType.prototype.onResize;
+        // Keep the node at the height the pill widget reports (legacy renderer only -
+        // Vue nodes size themselves from the DOM).
         nodeType.prototype.onResize = function () {
-            if (!this._measuredHeight) return;
-        
-            if (this.size[1] !== this._measuredHeight) {
-                this.setSize([this.size[0], this._measuredHeight]);
-                return;
+            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
+
+            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
+                this.setSize([this.size[0], this._erePillsHeight]);
             }
         };
 

--- a/web/prompt_cloud.js
+++ b/web/prompt_cloud.js
@@ -44,15 +44,5 @@ app.registerExtension({
             this.onUpdateTextWidget(this);
         };
 
-        // Keep the node at the height the pill widget reports (legacy renderer only -
-        // Vue nodes size themselves from the DOM).
-        nodeType.prototype.onResize = function () {
-            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
-
-            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
-                this.setSize([this.size[0], this._erePillsHeight]);
-            }
-        };
-
     }
 });

--- a/web/prompt_gallery.js
+++ b/web/prompt_gallery.js
@@ -60,15 +60,5 @@ app.registerExtension({
             this.onUpdateTextWidget(this);
         };
 
-        // Width stays freely resizable (the cards reflow on their own), height follows
-        // the content. Legacy renderer only - Vue nodes size themselves from the DOM.
-        nodeType.prototype.onResize = function () {
-            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
-
-            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
-                this.setSize([this.size[0], this._erePillsHeight]);
-            }
-        };
-
     }
 });

--- a/web/prompt_gallery.js
+++ b/web/prompt_gallery.js
@@ -1,6 +1,8 @@
 import { app } from "../../scripts/app.js";
 import { initializeSharedPromptFunctions, applyContextMenuPatch } from "./prompt.js";
-import { getCache } from "./js/cache.js";
+import { attachTagPillWidget } from "./js/pills.js";
+
+const DEFAULT_CARD_SIZE = 100;
 
 app.registerExtension({
     name: "ErePromptGallery",
@@ -12,23 +14,6 @@ app.registerExtension({
     beforeRegisterNodeDef(nodeType, nodeData, app) {
         if (nodeData.name !== "ErePromptGallery") return;
 
-        // Shared layout constants
-        let pillX = 10, 
-              pillY = 30,
-              pillW = 100, 
-              pillH = 100,
-              radius = 5,
-              spacing = 5, 
-              padding = 5;
-
-        const parseTags = value => {
-            try {
-                const parsed = JSON.parse(value || "[]");
-                if (Array.isArray(parsed)) return parsed;
-            } catch {}
-            return [];
-        };
-
         const origCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             if (origCreated) origCreated.apply(this, arguments);
@@ -37,355 +22,52 @@ app.registerExtension({
 
             const textWidget = node.widgets?.find(w => w.name === "text");
             textWidget.computeSize = () => [0, 0];
+            // `hidden` hides it in the legacy renderer, `options.hidden` in Vue nodes -
+            // they read different flags, and without the second one the raw tag JSON
+            // shows up as a textarea.
             textWidget.hidden = true;
+            textWidget.options = textWidget.options || {};
+            textWidget.options.hidden = true;
 
             // create properties defaults
             if (node.properties._tagImageWidth === null || node.properties._tagImageWidth === undefined) {
-                node.properties._tagImageWidth = pillW; // Default value
+                node.properties._tagImageWidth = DEFAULT_CARD_SIZE;
             }
             if (node.properties._tagImageHeight === null || node.properties._tagImageHeight === undefined) {
-                node.properties._tagImageHeight = pillH; // Default value
+                node.properties._tagImageHeight = DEFAULT_CARD_SIZE;
             }
-
-
-
-            node.onMouseDown = (e, pos) => {
-
-                const [x, y] = pos;
-
-                // Get background area
-                const bgX = pillX, bgY = pillY;
-                const bgW = node.size[0] - bgX * 2;
-                const bgH = node._tagAreaBottom - bgY;
-                if (x >= bgX && x <= bgX + bgW && y >= bgY && y <= bgY + bgH) {
-
-                    // Find if we are clicking pill
-                    let clickedPill = null;
-                    for (const pill of node._pillMap || []) {
-                        if (x >= pill.x && x <= pill.x + pill.w && y >= pill.y && y <= pill.y + pill.h) {
-                            clickedPill = pill;
-                            break;
-                        }
-                    }
-
-                    // Handle normal toggle click and quick edit shift click
-                    if (clickedPill) {
-                        node.onTagPillClick(e, pos, clickedPill);
-                    } 
-
-                }
-
-            };
 
             // Initialize all other functions shared between prompt nodes
             initializeSharedPromptFunctions(this, textWidget);
+
+            // Tag cards are a DOM widget so they render in both the legacy and the
+            // Vue node renderer; clicks are wired to the shared handlers inside.
+            // Images are plain <img> elements - the browser cache takes over the job
+            // the bitmap cache did for the canvas renderer.
+            attachTagPillWidget(node, {
+                variant: "gallery",
+                buttons: [
+                    { label: "button_menu", display: "≡", title: "Menu" },
+                    { label: "button_add_tag", display: "+", title: "Add tag" }
+                ],
+                getCardSize: () => [
+                    node.properties?._tagImageWidth ?? DEFAULT_CARD_SIZE,
+                    node.properties?._tagImageHeight ?? DEFAULT_CARD_SIZE
+                ]
+            });
+
             // Update on load
             this.onUpdateTextWidget(this);
-
         };
 
-        const origDraw = nodeType.prototype.onDrawForeground;
-        nodeType.prototype.onDrawForeground = function (ctx) {
-            if (origDraw) origDraw.call(this, ctx);
-            const textWidget = this.widgets?.find(w => w.name === "text");
-            if (!textWidget || this.flags?.collapsed) return;
-            
-            if (!this._pillImageCache) this._pillImageCache = new Map();
-            const tagData = parseTags(this.properties?._tagDataJSON || "[]");
-
-            // Custom size
-            const newPillW = this.properties?._tagImageWidth ?? pillW;
-            const newPillH = this.properties?._tagImageHeight ?? pillH;
-            if (this._cachedPillW !== newPillW || this._cachedPillH !== newPillH) {
-                this._pillImageCache.clear();
-                this._cachedPillW = newPillW;
-                this._cachedPillH = newPillH;
-            }
-            pillW = newPillW;
-            pillH = newPillH;
-
-            ctx.font = "12px monospace";
-
-            const pillMaxWidth = this.size[0] - pillX * 2;
-            let currentX = pillX;
-            let currentY = pillY;
-
-            const positions = [];
-            const specialTags = [
-                { label: "button_menu", display: "≡" },
-                { label: "button_add_tag", display: "+" } // this button tag need to show at end after all tag pills
-            ];
-    
-            // Creating buttons (fixed 20x20)
-            for (const { display, label } of specialTags) {
-                positions.push({ x: currentX, y: currentY, w: 20, h: 20, label, display, button: true });
-                currentX += 20 + spacing;
-            }
-
-            currentX = pillX;
-            currentY += 20 + padding;
-
-            for (const tag of tagData) {
-
-                let label = tag.name;
-                let displayName = tag.name;
-                if (tag.type === 'lora') {
-                    displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                } else if (tag.type === 'embedding') {
-                    displayName = displayName.replace(/^embedding:/, '');
-                } else if (tag.type === 'group') {
-                    displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                }
-
-                let display = displayName;
-                let textWidth = ctx.measureText(display).width;
-            
-                // Trim and append ellipsis if too wide
-                let maxTextWidth = pillW - padding * 2;
-                if (textWidth > maxTextWidth) {
-                    let i = display.length;
-                    const dots = "…";
-                    const dotsWidth = ctx.measureText("…").width;
-                    while (i > 0 && ctx.measureText(display.slice(0, i)).width + dotsWidth > maxTextWidth ) i--;
-                    display = display.slice(0, i) + dots;
-                }
-
-                // Prepare info pill data
-                let infoPillText = "";
-                if (tag.triggers && tag.triggers.length > 0) {
-                    infoPillText += `[+${tag.triggers.length}]`;
-                }
-                if (tag.strength && tag.strength !== 1.0) {
-                    if (infoPillText) infoPillText += " ";
-                    infoPillText += tag.strength.toFixed(2);
-                }
-
-                // calculate pill width
-                if (currentX + pillW > pillX + pillMaxWidth) {
-                    currentX = pillX;
-                    currentY += pillH + spacing;
-                }
-                positions.push({ x: currentX, y: currentY, w: pillW, h: pillH, label, display, active: !tag.active, type: tag.type, strength: tag.strength, infoPillText, triggers: tag.triggers });
-                currentX += pillW + spacing;
-            }
-
-
- 
-            // Store pill positions for click handling
-            this._pillMap = [];
-
-            // Check if all images are cached (either exist or not)
-            const imagesToLoad = [];
-            for (const p of positions) {
-                if (p.type === 'lora' || p.type === 'group' || p.type === 'embedding') {
-                    const imageUrl = `/erenodes/view/${p.type}/${p.label}?w=${p.w}&h=${p.h}&fit=cover`;
-                    p.imageUrl = imageUrl; // Store for later drawing
-
-                    // Only load if not cached yet (undefined), skip if cached (including notFound)
-                    const cached = getCache(imageUrl, 'bitmap');
-                    if (cached === undefined) { 
-                        imagesToLoad.push(imageUrl);
-                    }
-                }
-            }
-
-            // Force node reload after new images are cached
-            if (imagesToLoad.length > 0) {
-                // Use a flag to prevent multiple concurrent loads
-                if (!this._imagesLoading) {
-                    this._imagesLoading = true;
-                    // Since getCache now returns synchronous values, we can directly proceed
-                    const cachedUrls = imagesToLoad.map(imageUrl => getCache(imageUrl, 'bitmap')).filter(url => url);
-                    if (cachedUrls.length > 0) {
-                        this.setDirtyCanvas(true, true);
-                    }
-                    this._imagesLoading = false;
-                }
-            }
- 
-            for (const p of positions) {
- 
-                // pill background and image (cached)
-                ctx.beginPath();
-                ctx.fillStyle = "#222";
-                ctx.roundRect(p.x, p.y, p.w, p.h, radius);
-                ctx.fill();
-
-                // inactive filter
-                ctx.filter = p.button ? "" : (p.active ? "grayscale(0.75)" : "grayscale(0)");
-                ctx.globalAlpha = p.button ? 1 : (p.active ? 0.25 : 1);
-
-                // Direct draw path (avoid offscreen canvas to reduce overhead).
-                const TagImage = p.imageUrl ? getCache(p.imageUrl, 'bitmap') : null;
-                if (TagImage && TagImage instanceof ImageBitmap) {
-                    // Clip to rounded rect
-                    ctx.save();
-                    ctx.beginPath();
-                    ctx.roundRect(p.x, p.y, p.w, p.h, radius);
-                    ctx.clip();
-
-                    // Compute cover crop once and draw directly to main canvas
-                    const imgAspectRatio = TagImage.width / TagImage.height;
-                    const areaAspectRatio = p.w / p.h;
-                    let sx = 0, sy = 0, sWidth = TagImage.width, sHeight = TagImage.height;
-                    if (imgAspectRatio > areaAspectRatio) {
-                        sWidth = TagImage.height * areaAspectRatio;
-                        sx = (TagImage.width - sWidth) / 2;
-                    } else {
-                        sHeight = TagImage.width / areaAspectRatio;
-                        sy = (TagImage.height - sHeight) / 2;
-                    }
-                    ctx.drawImage(TagImage, sx, sy, sWidth, sHeight, p.x, p.y, p.w, p.h);
-                    ctx.restore();
-                }
-
-                // reset filter
-                ctx.globalAlpha = 1.0;
-                ctx.filter = "none";
- 
-                // pill border
-                ctx.beginPath();
-                ctx.roundRect(p.x, p.y, p.w, p.h, radius);
-                ctx.strokeStyle = "#444";
-                ctx.lineWidth = 1;
-                ctx.stroke();
-
-                // ** and added border around both background and image
-
-                // ** and now actuall name pill, lowered by pillH - 20 and with height 20
-                // ** this part other than position and size remains direct copy from cloud
-                ctx.beginPath();
-                ctx.globalAlpha = p.button ? 1 : (p.active ? 0.5 : 1);
-                let pillFill = "#414650"; // Default
-                if (p.type === 'lora') {
-                    pillFill = "#415041"; // Muted green-cyan
-                } else if (p.type === 'embedding') {
-                    pillFill = "#504149 "; // Muted yellow
-                } else if (p.type === 'group') {
-                    pillFill = "#504C41"; // Muted orange/brown
-                }
-                ctx.fillStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? LiteGraph.WIDGET_BGCOLOR : pillFill);
-                // ctx.roundRect(p.x, p.y, p.w, p.h, 6); 
-                ctx.roundRect(p.x, (p.y + p.h - 20), p.w, 20, (p.button ? radius : [0, 0, radius, radius]));
-                ctx.fill();
-            
-                ctx.strokeStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? "#444" : pillFill);
-                ctx.lineWidth = 1;
-                ctx.stroke();
-
-                ctx.textBaseline = "middle";
-                const textX = p.x + (p.button ? p.w / 2 : padding);
-                const textY = p.y + p.h - 20 + (20 / 2 + 1);
-                
-                if(p.button) {
-                    ctx.textAlign = "center";
-                    ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-                    ctx.fillText(p.display, textX, textY);
-                } else {
-                    ctx.textAlign = "left";
-                    ctx.fillStyle = (p.active ? LiteGraph.WIDGET_TEXT_COLOR : "#FFF");
-                    ctx.fillText(p.display, textX, textY);
-                }
-
-                // Draw info pill in upper right corner if there's info to show
-                if (!p.button && p.infoPillText) {
-                    ctx.font = "10px monospace";
-                    const infoPillWidth = ctx.measureText(p.infoPillText).width + 5;
-                    const infoPillX = p.x + p.w - infoPillWidth - 2.5;
-                    const infoPillY = p.y + 2.5;
-                    
-                    ctx.globalAlpha = p.button ? 1 : (p.active ? 0.5 : 0.75);
-                    // Draw info pill background
-                    ctx.fillStyle = "#222";
-                    ctx.beginPath();
-                    ctx.roundRect(infoPillX, infoPillY, infoPillWidth, 15, radius);
-                    ctx.fill();
-                    
-                    // Draw info pill text
-                    ctx.fillStyle = "#FFF";
-                    ctx.textAlign = "center";
-                    ctx.textBaseline = "middle";
-                    ctx.fillText(p.infoPillText, infoPillX + infoPillWidth / 2, infoPillY + 15 / 2 + 1);
-                }
-
-                ctx.globalAlpha = 1;
-                ctx.textBaseline = "alphabetic";
-                ctx.font = "12px monospace";
-            
-                this._pillMap.push({ x: p.x, y: p.y, w: p.w, h: p.h, label: p.label, button: p.button });
-            }
-            
-            this._tagAreaBottom = currentY + pillH + padding;
-            this._measuredHeight = currentY + pillH + pillX;
-
-            // Height correction
-            if (isFinite(this._measuredHeight) && this._measuredHeight && this.size[1] !== this._measuredHeight) {
-                this.setSize([this.size[0], this._measuredHeight]);
-				this.setDirtyCanvas(true, true);
-            }
-            
-        };
-        
-        const origResize = nodeType.prototype.onResize;
+        // Width stays freely resizable (the cards reflow on their own), height follows
+        // the content. Legacy renderer only - Vue nodes size themselves from the DOM.
         nodeType.prototype.onResize = function () {
-            if (this._pillImageCache) this._pillImageCache.clear();
+            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
 
-            // Allow horizontal resizing only, snap to valid widths for 1 to N pills per row (N = total pills/tags, not including special buttons)
-            let tagData = JSON.parse(this.properties?._tagDataJSON || "[]");
-            // Custom size
-            pillW = this.properties?._tagImageWidth ?? pillW;
-            pillH = this.properties?._tagImageHeight ?? pillH;
-
-            let totalPills = tagData?.length || 0;
-            if (totalPills === 0) totalPills = 1;
-            // Allow resizing up to a reasonable max columns (e.g., 12)
-            const maxColumns = 12;
-            let snapPoints = [];
-            // for (let n = 1; n <= totalPills; n++) {
-            for (let n = 1; n <= Math.max(totalPills, maxColumns); n++) {
-                snapPoints.push(pillX * 2 + n * pillW + (n - 1) * spacing);
+            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
+                this.setSize([this.size[0], this._erePillsHeight]);
             }
-
-            // Clamp width to max allowed (all pills/tags in one row)
-            // let width = this.size[0];
-            // const maxAllowedWidth = snapPoints[snapPoints.length - 1];
-            // if (width > maxAllowedWidth) width = maxAllowedWidth;
-        
-            // Find the closest snap point
-
-            let snappedWidth = snapPoints[0];
-            for (let i = 0; i < snapPoints.length; i++) {
-                if (this.size[0] < snapPoints[i]) {
-                    // Snap to previous if closer, else to this one
-                    if (i > 0 && Math.abs(this.size[0] - snapPoints[i-1]) < Math.abs(this.size[0] - snapPoints[i])) {
-                        snappedWidth = snapPoints[i-1];
-                    } else {
-                        snappedWidth = snapPoints[i];
-                    }
-                    break;
-                }
-                snappedWidth = snapPoints[i];
-            }
-            // Always set height to measured height (no vertical resizing)
-            const measuredHeight = this._measuredHeight || this.size[1];
-            // Prevent infinite resize loop: round values before comparing
-            const newWidth = Math.round(snappedWidth);
-            const newHeight = Math.round(measuredHeight);
-            if (this.size[0] !== newWidth || this.size[1] !== newHeight) {
-                this.setSize([newWidth, newHeight]);
-                return;
-            }
-            if (origResize) origResize.call(this);
-            app.graph.setDirtyCanvas(true);
-        };
-        
-        const origRemove = nodeType.prototype.onRemove;
-        nodeType.prototype.onRemove = function () {
-            if (this._pillImageCache) this._pillImageCache.clear();
         };
 
     }

--- a/web/prompt_multiline.js
+++ b/web/prompt_multiline.js
@@ -1,8 +1,6 @@
 import { app } from "../../scripts/app.js";
-import { initializeSharedPromptFunctions, addLayoutSpacer, getSpacerTop } from "./prompt.js";
-
-// Height of the strip kept free below the textarea for the erenodes button row
-const BUTTON_ROW_HEIGHT = 30;
+import { initializeSharedPromptFunctions } from "./prompt.js";
+import { attachTagPillWidget } from "./js/pills.js";
 
 app.registerExtension({
     name: "ErePromptMultiline",
@@ -17,97 +15,23 @@ app.registerExtension({
             const node = this;
 
             const textWidget = node.widgets?.find(w => w.name === "text");
-            
-            node.onMouseDown = (e, pos) => {
-
-                const [x, y] = pos;
-
-                // The textarea covers the rest of the node body, so the only clickable
-                // area here is the button row - test the buttons directly.
-                let clickedPill = null;
-                for (const pill of node._pillMap || []) {
-                    if (x >= pill.x && x <= pill.x + pill.w && y >= pill.y && y <= pill.y + pill.h) {
-                        clickedPill = pill;
-                        break;
-                    }
-                }
-
-                // Handle normal toggle click
-                // no need to check shift click because we only show menu button
-                if (clickedPill) {
-                    node.onTagPillClick(e, pos, clickedPill);
-                }
-
-            };
 
             // Initialize all other functions shared between prompt nodes
             initializeSharedPromptFunctions(this, textWidget);
 
+            // This node keeps its textarea, so the widget only carries the action button.
+            // As a DOM widget it takes part in the layout of both renderers, which is what
+            // keeps it from ending up underneath the textarea.
+            attachTagPillWidget(node, {
+                variant: "buttons",
+                autoHeight: false,
+                buttons: [
+                    { label: "button_menu", display: "≡", title: "Menu" }
+                ]
+            });
+
             // Update on load
             this.onUpdateTextWidget(this);
-
-            // Keep a strip below the textarea free for the action button
-            node._buttonRowSpacer = addLayoutSpacer(node, "erenodes_button_row", BUTTON_ROW_HEIGHT);
-        };
-        
-        const origDraw = nodeType.prototype.onDrawForeground;
-        nodeType.prototype.onDrawForeground = function (ctx) {
-            if (origDraw) origDraw.call(this, ctx);
-            const textWidget = this.widgets?.find(w => w.name === "text");
-            if (!textWidget || this.flags?.collapsed) return;
-        
-            ctx.font = "12px monospace";
-
-            // The buttons live in the strip reserved by the spacer widget, below the textarea.
-            const pillX = 10, spacing = 5, pillPadding = 5;
-            const pillY = getSpacerTop(this._buttonRowSpacer, this.size[1] - BUTTON_ROW_HEIGHT) + pillPadding;
-            let currentX = pillX;
-            let currentY = pillY;
-
-            const positions = [];
-            const specialTags = [
-                { label: "button_menu", display: "≡" }
-            ];
-
-            for (const { display, label } of specialTags) {
-                const pillMaxWidth = this.size[0] - pillX * 2;
-                if (currentX + 20 > pillX + pillMaxWidth) {
-                    currentX = pillX;
-                    currentY += 20 + spacing;
-                }
-                positions.push({ x: currentX, y: currentY, w: 20, h: 20, label, display, button: true });
-                currentX += 20 + spacing;
-            }
-
-
-            const pillHeight = (currentY + 20 + pillPadding) - pillY;
-            this._tagAreaBottom = pillY + pillHeight;
-
-            // Store pill positions for click handling
-            this._pillMap = [];
-
-            for (const p of positions) {
-                ctx.beginPath();
-
-                let pillFill = "#414650"; // Default
-                ctx.fillStyle = LiteGraph.NODE_DEFAULT_BOXCOLOR;
-                ctx.roundRect(p.x, p.y, p.w, p.h, 6);
-                ctx.fill();
-
-                ctx.textBaseline = "middle";
-                const textX = p.x + (p.button ? p.w / 2 : 6);
-                const textY = p.y + p.h / 2 + 1;
-                
-                ctx.textAlign = "center";
-                ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-                ctx.fillText(p.display, textX, textY);
-
-                ctx.textBaseline = "alphabetic";
-                ctx.globalCompositeOperation='source-atop';
-                this._pillMap.push({ x: p.x, y: p.y, w: p.w, h: p.h, label: p.label, button: p.button });
-                ctx.globalCompositeOperation='source-over';
-            }
-            
         };
 
     }

--- a/web/prompt_multiline.js
+++ b/web/prompt_multiline.js
@@ -1,5 +1,8 @@
 import { app } from "../../scripts/app.js";
-import { initializeSharedPromptFunctions } from "./prompt.js";
+import { initializeSharedPromptFunctions, addLayoutSpacer, getSpacerTop } from "./prompt.js";
+
+// Height of the strip kept free below the textarea for the erenodes button row
+const BUTTON_ROW_HEIGHT = 30;
 
 app.registerExtension({
     name: "ErePromptMultiline",
@@ -19,27 +22,20 @@ app.registerExtension({
 
                 const [x, y] = pos;
 
-                // Get background area
-                const bgX = 10, bgY = 35;
-                const bgW = node.size[0] - bgX * 2;
-                const bgH = node._tagAreaBottom - bgY;
-                if (x >= bgX && x <= bgX + bgW && y >= bgY && y <= bgY + bgH) {
-
-                    // Find if we are clicking pill
-                    let clickedPill = null;
-                    for (const pill of node._pillMap || []) {
-                        if (x >= pill.x && x <= pill.x + pill.w && y >= pill.y && y <= pill.y + pill.h) {
-                            clickedPill = pill;
-                            break;
-                        }
+                // The textarea covers the rest of the node body, so the only clickable
+                // area here is the button row - test the buttons directly.
+                let clickedPill = null;
+                for (const pill of node._pillMap || []) {
+                    if (x >= pill.x && x <= pill.x + pill.w && y >= pill.y && y <= pill.y + pill.h) {
+                        clickedPill = pill;
+                        break;
                     }
+                }
 
-                    // Handle normal toggle click
-                    // no need to check shift click because we only show menu button
-                    if (clickedPill) {
-                        node.onTagPillClick(e, pos, clickedPill);
-                    } 
-
+                // Handle normal toggle click
+                // no need to check shift click because we only show menu button
+                if (clickedPill) {
+                    node.onTagPillClick(e, pos, clickedPill);
                 }
 
             };
@@ -49,10 +45,9 @@ app.registerExtension({
 
             // Update on load
             this.onUpdateTextWidget(this);
-            
-            // Dummy button to make space for action button
-            let fakeButton = node.addWidget("button", "Placeholder", "fake_button", () => {});
-            fakeButton.hidden = true;
+
+            // Keep a strip below the textarea free for the action button
+            node._buttonRowSpacer = addLayoutSpacer(node, "erenodes_button_row", BUTTON_ROW_HEIGHT);
         };
         
         const origDraw = nodeType.prototype.onDrawForeground;
@@ -63,8 +58,9 @@ app.registerExtension({
         
             ctx.font = "12px monospace";
 
-            // if we can't reorder widgets, we need to move pill to the bottom of the node where butotn makes space. For now leave it like that. 
-            const pillX = 10, pillY = this.size[1] - 30, spacing = 5, pillPadding = 5;
+            // The buttons live in the strip reserved by the spacer widget, below the textarea.
+            const pillX = 10, spacing = 5, pillPadding = 5;
+            const pillY = getSpacerTop(this._buttonRowSpacer, this.size[1] - BUTTON_ROW_HEIGHT) + pillPadding;
             let currentX = pillX;
             let currentY = pillY;
 

--- a/web/prompt_multiselect.js
+++ b/web/prompt_multiselect.js
@@ -48,15 +48,5 @@ app.registerExtension({
             this.onUpdateTextWidget(this);
         };
 
-        // Keep the node at the height the pill widget reports (legacy renderer only -
-        // Vue nodes size themselves from the DOM).
-        nodeType.prototype.onResize = function () {
-            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
-
-            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
-                this.setSize([this.size[0], this._erePillsHeight]);
-            }
-        };
-
     }
 });

--- a/web/prompt_multiselect.js
+++ b/web/prompt_multiselect.js
@@ -1,5 +1,6 @@
 import { app } from "../../scripts/app.js";
 import { initializeSharedPromptFunctions, applyContextMenuPatch } from "./prompt.js";
+import { attachTagPillWidget, openInactiveTagsMenu } from "./js/pills.js";
 
 app.registerExtension({
     name: "ErePromptMultiSelect",
@@ -11,22 +12,6 @@ app.registerExtension({
     beforeRegisterNodeDef(nodeType, nodeData, app) {
         if (nodeData.name !== "ErePromptMultiSelect") return;
 
-        // Shared layout constants
-        const pillX = 10, 
-              pillY = 30,
-              pillH = 20,
-              radius = 5,
-              spacing = 5, 
-              padding = 5;
-
-        const parseTags = value => {
-            try {
-                const parsed = JSON.parse(value || "[]");
-                if (Array.isArray(parsed)) return parsed;
-            } catch {}
-            return [];
-        };
-
         const origCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             if (origCreated) origCreated.apply(this, arguments);
@@ -35,230 +20,41 @@ app.registerExtension({
 
             const textWidget = node.widgets?.find(w => w.name === "text");
             textWidget.computeSize = () => [0, 0];
+            // `hidden` hides it in the legacy renderer, `options.hidden` in Vue nodes -
+            // they read different flags, and without the second one the raw tag JSON
+            // shows up as a textarea.
             textWidget.hidden = true;
-
-            node.onMouseDown = (e, pos) => {
-
-                const [x, y] = pos;
-
-                // Get background area
-                const bgX = 10, bgY = 30;
-                const bgW = node.size[0] - bgX * 2;
-                const bgH = node._tagAreaBottom - bgY;
-                if (x >= bgX && x <= bgX + bgW && y >= bgY && y <= bgY + bgH) {
-
-                    // Find if we are clicking pill
-                    let clickedPill = null;
-                    for (const pill of node._pillMap || []) {
-                        if (x >= pill.x && x <= pill.x + pill.w && y >= pill.y && y <= pill.y + pill.h) {
-                            clickedPill = pill;
-                            pos = [pill.x, pill.y + pill.h];
-                            break;
-                        }
-                    }
-
-                    // Handle normal toggle click and qucik edit shift click
-                    if (clickedPill) {
-                        node.onTagPillClick(e, pos, clickedPill);
-                    // Open dropdown on background click tag selection
-                    } else {
-
-                        const tagData = parseTags(node.properties._tagDataJSON || textWidget.value);
-                        const inactive = tagData.filter(t => !t.active && t.name);
-        
-                        const dropdownOptions = inactive.map(tag => ({
-                            content: tag.name,
-                            callback: () => {
-                                const entry = tagData.find(t => t.name === tag.name);
-                                if (entry) entry.active = true;
-                                node.properties._tagDataJSON = JSON.stringify(tagData, null, 2);
-                                this.onUpdateTextWidget(this);
-                            }
-                        }));
-        
-                        if (dropdownOptions.length > 0) {
-                            new LiteGraph.ContextMenu(dropdownOptions, { event: e, className: "dark" }, window);
-                        }  
-
-                    }
-
-                }
-                
-            };
+            textWidget.options = textWidget.options || {};
+            textWidget.options.hidden = true;
 
             // Initialize all other functions shared between prompt nodes
             initializeSharedPromptFunctions(this, textWidget);
 
+            // Tag pills are a DOM widget so they render in both the legacy and the
+            // Vue node renderer; clicks are wired to the shared handlers inside.
+            attachTagPillWidget(node, {
+                variant: "chips",
+                framed: true,
+                showInactive: false,
+                buttons: [
+                    { label: "button_menu", display: "≡", title: "Menu" },
+                    { label: "button_add_tag", display: "+", title: "Add tag" }
+                ],
+                // Clicking the empty area offers the tags that are currently off
+                onBackgroundClick: e => openInactiveTagsMenu(node, e)
+            });
+
             // Update on load
             this.onUpdateTextWidget(this);
-            
         };
 
-        const origDraw = nodeType.prototype.onDrawForeground;
-        nodeType.prototype.onDrawForeground = function (ctx) {
-            if (origDraw) origDraw.call(this, ctx);
-
-            const textWidget = this.widgets?.find(w => w.name === "text");
-            if (!textWidget || this.flags?.collapsed) return;
-
-            const tagData = parseTags(this.properties._tagDataJSON || textWidget.value);
-
-            ctx.font = "12px monospace";
-
-            const pillMaxWidth = this.size[0] - pillX * 2 - padding * 2;
-            let currentX = pillX + padding;
-            let currentY = pillY + padding;
-
-            const positions = [];
-            const specialTags = [
-                { label: "button_menu", display: "≡" },
-                { label: "button_add_tag", display: "+" }
-            ];
-              
-            // Creating buttons
-            for (const { display, label } of specialTags) {
-                if (currentX + pillH > pillX + pillMaxWidth - padding) {
-                    currentX = pillX + padding;
-                    currentY += pillH + spacing;
-                }
-                positions.push({ x: currentX, y: currentY, w: 20, h: 20, label, display, button: true });
-                currentX += pillH + spacing;
-            }
-
-            // Creating pills
-            for (const tag of tagData) {
-
-                // don't draw inactive tags
-                if (!tag.active) continue;
-
-                let label = tag.name;
-                let displayName = tag.name;
-                if (tag.type === 'lora') {
-                    // displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                    if (tag.triggers && tag.triggers.length > 0) {
-                        displayName += ` [+${tag.triggers.length}]`;
-                    }
-                } else if (tag.type === 'embedding') {
-                    displayName = displayName.replace(/^embedding:/, '');
-                } else if (tag.type === 'group') {
-                    // displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                }
-
-                let strengthText = "";
-                if (tag.strength && tag.strength !== 1.0) {
-                    tag.strength = tag.strength.toFixed(2);
-                    strengthText = ` ${tag.strength}`;
-                }
-
-                let display = displayName;
-                let strengthWidth = ctx.measureText(strengthText).width;
-                let textWidth = ctx.measureText(display).width + strengthWidth;
-            
-                // Trim and append ellipsis if too wide
-                let maxTextWidth = pillMaxWidth - padding * 2;
-                if (textWidth > pillMaxWidth - padding * 2) {
-                    let i = display.length;
-                    const dots = "…";
-                    const dotsWidth = ctx.measureText("…").width;
-                    while (i > 0 && ctx.measureText(display.slice(0, i)).width + dotsWidth + strengthWidth > maxTextWidth ) i--;
-                    display = display.slice(0, i) + dots;
-                }
-
-                // calculate pill width
-                const pillW = Math.min(textWidth + padding * 2, pillMaxWidth);
-            
-                if (currentX + pillW > pillX + pillMaxWidth + padding) {
-                    currentX = pillX + padding;
-                    currentY += pillH + spacing;
-                }
-            
-                positions.push({ x: currentX, y: currentY, w: pillW, h: pillH, label, display, active: !tag.active, type: tag.type, strength: tag.strength });
-                currentX += pillW + spacing;
-            }
-
-
-            this._pillMap = [];
-
-            const pillBackgroundHeight = (currentY + pillH + padding) - pillY;
-            // // Draw background around pills
-            ctx.beginPath();
-            ctx.fillStyle = LiteGraph.WIDGET_BGCOLOR;
-            ctx.strokeStyle = "#444";
-            ctx.lineWidth = 1;
-            ctx.roundRect(pillX, pillY, pillMaxWidth + padding * 2, pillBackgroundHeight, radius);
-            ctx.fill();
-            ctx.stroke();
-
-            // Drawing pills
-            for (const p of positions) {
-                ctx.beginPath();
-                ctx.globalAlpha = p.button ? 1 : (p.active ? 0.75 : 1);
-
-                let pillFill = "#414650"; // Default
-                if (p.type === 'lora') {
-                    pillFill = "#415041"; // Muted green-cyan
-                } else if (p.type === 'embedding') {
-                    pillFill = "#504149 "; // Muted yellow
-                } else if (p.type === 'group') {
-                    pillFill = "#504C41"; // Muted orange/brown
-                }
-                ctx.fillStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? LiteGraph.WIDGET_BGCOLOR : pillFill);
-                ctx.roundRect(p.x, p.y, p.w, p.h, radius);
-                ctx.fill();
-            
-                ctx.strokeStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? "#444" : pillFill);
-                ctx.lineWidth = 1;
-                ctx.stroke();
-
-                ctx.textBaseline = "middle";
-                const textX = p.x + (p.button ? p.w / 2 : padding);
-                const textY = p.y + p.h / 2 + 1;
-                
-                if(p.button) {
-                    ctx.textAlign = "center";
-                    ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-                    ctx.fillText(p.display, textX, textY);
-                } else {
-                    ctx.textAlign = "left";
-                    ctx.fillStyle = (p.active ? LiteGraph.WIDGET_TEXT_COLOR : "#FFF");
-                    ctx.fillText(p.display, textX, textY);
-
-                    if (p.strength && p.strength !== 1.0) {
-                        const nameWidth = ctx.measureText(p.display).width;
-                        const strengthText = ` ${p.strength}`;
-                        ctx.globalAlpha = 0.5;
-                        ctx.fillText(strengthText, textX + nameWidth, textY);
-                        ctx.globalAlpha = 1;
-                    }
-                }
-
-                ctx.textBaseline = "alphabetic";
-            
-                this._pillMap.push({ x: p.x, y: p.y, w: p.w, h: p.h, label: p.label, button: p.button });
-            }
-            
-            this._tagAreaBottom = currentY + pillH + padding;
-            this._measuredHeight = currentY + pillH + pillX + padding;
-
-            // Height correction
-            if (isFinite(this._measuredHeight) && this._measuredHeight && this.size[1] !== this._measuredHeight) {
-                this.setSize([this.size[0], this._measuredHeight]);
-				this.setDirtyCanvas(true, true);
-            }
-
-        };
-        
-        const origResize = nodeType.prototype.onResize;
+        // Keep the node at the height the pill widget reports (legacy renderer only -
+        // Vue nodes size themselves from the DOM).
         nodeType.prototype.onResize = function () {
-            if (!this._measuredHeight) return;
-        
-            if (this.size[1] !== this._measuredHeight) {
-                this.setSize([this.size[0], this._measuredHeight]);
-                return;
+            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
+
+            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
+                this.setSize([this.size[0], this._erePillsHeight]);
             }
         };
 

--- a/web/prompt_randomizer.js
+++ b/web/prompt_randomizer.js
@@ -79,15 +79,5 @@ app.registerExtension({
             this.onUpdateTextWidget(this);
         };
 
-        // Keep the node at the height the pill widget reports (legacy renderer only -
-        // Vue nodes size themselves from the DOM).
-        nodeType.prototype.onResize = function () {
-            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
-
-            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
-                this.setSize([this.size[0], this._erePillsHeight]);
-            }
-        };
-
     }
 });

--- a/web/prompt_randomizer.js
+++ b/web/prompt_randomizer.js
@@ -1,19 +1,20 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
-import { initializeSharedPromptFunctions, applyContextMenuPatch, addLayoutSpacer, getSpacerTop } from "./prompt.js";
+import { initializeSharedPromptFunctions, applyContextMenuPatch } from "./prompt.js";
+import { attachTagPillWidget, openInactiveTagsMenu } from "./js/pills.js";
 
 app.registerExtension({
     name: "ErePromptRandomizer",
 
     setup() {
         applyContextMenuPatch();
-        
+
         api.addEventListener("status", ({ detail }) => {
             if (detail?.exec_info?.queue_remaining === 0) {
                 setTimeout(() => {
                     const graph = app.graph;
                     if (!graph?._nodes) return;
-    
+
                     for (const node of graph._nodes) {
                         if (node.type === "ErePromptRandomizer") {
                             const controlWidget = node.widgets?.find(w => w.name === "control after generate");
@@ -37,22 +38,6 @@ app.registerExtension({
     beforeRegisterNodeDef(nodeType, nodeData, app) {
         if (nodeData.name !== "ErePromptRandomizer") return;
 
-        // Shared layout constants
-        const pillX = 10,
-              pillYFallback = 30,
-              pillH = 20,
-              radius = 5,
-              spacing = 5, 
-              padding = 5;
-
-        const parseTags = value => {
-            try {
-                const parsed = JSON.parse(value || "[]");
-                if (Array.isArray(parsed)) return parsed;
-            } catch {}
-            return [];
-        };
-
         const origCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             if (origCreated) origCreated.apply(this, arguments);
@@ -61,248 +46,46 @@ app.registerExtension({
 
             const textWidget = node.widgets?.find(w => w.name === "text");
             textWidget.computeSize = () => [0, 0];
+            // `hidden` hides it in the legacy renderer, `options.hidden` in Vue nodes -
+            // they read different flags, and without the second one the raw tag JSON
+            // shows up as a textarea.
             textWidget.hidden = true;
-
-            // Reserves the pill area in the widget layout, so the control below never
-            // overlaps it. Height is kept in sync from onDrawForeground.
-            node._pillAreaSpacer = addLayoutSpacer(node, "erenodes_pill_area", 0);
-
-            // Randomize control
-            node.addWidget("combo", "control after generate", "fixed", "control_after_generate", { values: ["fixed", "increment", "decrement", "randomize"] });
-
-            node.onMouseDown = (e, pos) => {
-
-                const [x, y] = pos;
-
-                // Get background area
-                const bgX = 10, bgY = getSpacerTop(node._pillAreaSpacer, pillYFallback);
-                const bgW = node.size[0] - bgX * 2;
-                const bgH = node._tagAreaBottom - bgY;
-                if (x >= bgX && x <= bgX + bgW && y >= bgY && y <= bgY + bgH) {
-
-                    // Find if we are clicking pill
-                    let clickedPill = null;
-                    for (const pill of node._pillMap || []) {
-                        if (x >= pill.x && x <= pill.x + pill.w && y >= pill.y && y <= pill.y + pill.h) {
-                            clickedPill = pill;
-                            pos = [pill.x, pill.y + pill.h];
-                            break;
-                        }
-                    }
-
-                    // Handle normal toggle click and qucik edit shift click
-                    if (clickedPill) {
-                        node.onTagPillClick(e, pos, clickedPill);
-                    // Open dropdown on background click tag selection
-                    } else {
-
-                        const tagData = parseTags(node.properties._tagDataJSON || textWidget.value);
-                        const inactive = tagData.filter(t => !t.active && t.name);
-        
-                        const dropdownOptions = inactive.map(tag => ({
-                            content: tag.name,
-                            callback: () => {
-                                const entry = tagData.find(t => t.name === tag.name);
-                                if (entry) entry.active = true;
-                                node.properties._tagDataJSON = JSON.stringify(tagData, null, 2);
-                                this.onUpdateTextWidget(this);
-                            }
-                        }));
-        
-                        if (dropdownOptions.length > 0) {
-                            new LiteGraph.ContextMenu(dropdownOptions, { event: e, className: "dark" }, window);
-                        }  
-
-                    }
-
-                }
-                
-            };
+            textWidget.options = textWidget.options || {};
+            textWidget.options.hidden = true;
 
             // Initialize all other functions shared between prompt nodes
             initializeSharedPromptFunctions(this, textWidget);
 
+            // Tag pills are a DOM widget so they render in both the legacy and the
+            // Vue node renderer; clicks are wired to the shared handlers inside.
+            // Added before the control widget so that one sits below the pills.
+            attachTagPillWidget(node, {
+                variant: "chips",
+                framed: true,
+                showInactive: false,
+                buttons: [
+                    { label: "button_menu", display: "≡", title: "Menu" },
+                    { label: "button_add_tag", display: "+", title: "Add tag" },
+                    { label: "button_randomize", display: "🎲︎", title: "Randomize" }
+                ],
+                // Clicking the empty area offers the tags that are currently off
+                onBackgroundClick: e => openInactiveTagsMenu(node, e)
+            });
+
+            // Randomize control
+            node.addWidget("combo", "control after generate", "fixed", "control_after_generate", { values: ["fixed", "increment", "decrement", "randomize"] });
+
             // Update on load
             this.onUpdateTextWidget(this);
-            
         };
 
-        const origDraw = nodeType.prototype.onDrawForeground;
-        nodeType.prototype.onDrawForeground = function (ctx) {
-            if (origDraw) origDraw.call(this, ctx);
-
-            const textWidget = this.widgets?.find(w => w.name === "text");
-            if (!textWidget || this.flags?.collapsed) return;
-
-            const tagData = parseTags(this.properties._tagDataJSON || textWidget.value);
-
-            ctx.font = "12px monospace";
-
-            // Anchor the pill area to the space reserved in the widget layout
-            const pillY = getSpacerTop(this._pillAreaSpacer, pillYFallback);
-            const pillMaxWidth = this.size[0] - pillX * 2 - padding * 2;
-            let currentX = pillX + padding;
-            let currentY = pillY + padding;
-
-            const positions = [];
-            const specialTags = [
-                { label: "button_menu", display: "≡" },
-                { label: "button_add_tag", display: "+" },
-                { label: "button_randomize", display: "🎲︎" },
-            ];
-              
-            // Creating buttons
-            for (const { display, label } of specialTags) {
-                if (currentX + pillH > pillX + pillMaxWidth - padding) {
-                    currentX = pillX + padding;
-                    currentY += pillH + spacing;
-                }
-                positions.push({ x: currentX, y: currentY, w: 20, h: 20, label, display, button: true });
-                currentX += pillH + spacing;
-            }
-
-            // Creating pills
-            for (const tag of tagData) {
-                
-                // don't draw inactive tags
-                if (!tag.active) continue;
-
-                let label = tag.name;
-                let displayName = tag.name;
-                if (tag.type === 'lora') {
-                    // displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                    if (tag.triggers && tag.triggers.length > 0) {
-                        displayName += ` [+${tag.triggers.length}]`;
-                    }
-                } else if (tag.type === 'embedding') {
-                    displayName = displayName.replace(/^embedding:/, '');
-                } else if (tag.type === 'group') {
-                    // displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                }
-
-                let strengthText = "";
-                if (tag.strength && tag.strength !== 1.0) {
-                    tag.strength = tag.strength.toFixed(2);
-                    strengthText = ` ${tag.strength}`;
-                }
-
-                let display = displayName;
-                let strengthWidth = ctx.measureText(strengthText).width;
-                let textWidth = ctx.measureText(display).width + strengthWidth;
-            
-                // Trim and append ellipsis if too wide
-                const maxTextWidth = pillMaxWidth - padding * 2;
-                if (textWidth > pillMaxWidth - padding * 2) {
-                    let i = display.length;
-                    const dots = "…";
-                    const dotsWidth = ctx.measureText("…").width;
-                    while (i > 0 && ctx.measureText(display.slice(0, i)).width + dotsWidth + strengthWidth > maxTextWidth ) i--;
-                    display = display.slice(0, i) + dots;
-                }
-
-                // calculate pill width
-                const pillW = Math.min(textWidth + padding * 2, pillMaxWidth);
-            
-                if (currentX + pillW > pillX + pillMaxWidth + padding) {
-                    currentX = pillX + padding;
-                    currentY += pillH + spacing;
-                }
-            
-                positions.push({ x: currentX, y: currentY, w: pillW, h: pillH, label, display, active: !tag.active, type: tag.type, strength: tag.strength });
-                currentX += pillW + spacing;
-            }
-
-
-            this._pillMap = [];
-
-            const pillBackgroundHeight = (currentY + pillH + padding) - pillY;
-            // // Draw background around pills
-            ctx.beginPath();
-            ctx.fillStyle = LiteGraph.WIDGET_BGCOLOR;
-            ctx.strokeStyle = "#444";
-            ctx.lineWidth = 1;
-            ctx.roundRect(pillX, pillY, pillMaxWidth + padding * 2, pillBackgroundHeight, radius);
-            ctx.fill();
-            ctx.stroke();
-
-            // Drawing pills
-            for (const p of positions) {
-                ctx.beginPath();
-                ctx.globalAlpha = p.button ? 1 : (p.active ? 0.75 : 1);
-
-                let pillFill = "#414650"; // Default
-                if (p.type === 'lora') {
-                    pillFill = "#415041"; // Muted green-cyan
-                } else if (p.type === 'embedding') {
-                    pillFill = "#504149 "; // Muted yellow
-                } else if (p.type === 'group') {
-                    pillFill = "#504C41"; // Muted orange/brown
-                }
-                ctx.fillStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? LiteGraph.WIDGET_BGCOLOR : pillFill);
-                ctx.roundRect(p.x, p.y, p.w, p.h, radius);
-                ctx.fill();
-            
-                ctx.strokeStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? "#444" : pillFill);
-                ctx.lineWidth = 1;
-                ctx.stroke();
-
-                ctx.textBaseline = "middle";
-                const textX = p.x + (p.button ? p.w / 2 : padding);
-                const textY = p.y + p.h / 2 + 1;
-                
-                if(p.button) {
-                    ctx.textAlign = "center";
-                    ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-                    ctx.fillText(p.display, textX, textY);
-                } else {
-                    ctx.textAlign = "left";
-                    ctx.fillStyle = (p.active ? LiteGraph.WIDGET_TEXT_COLOR : "#FFF");
-                    ctx.fillText(p.display, textX, textY);
-
-                    if (p.strength && p.strength !== 1.0) {
-                        const nameWidth = ctx.measureText(p.display).width;
-                        const strengthText = ` ${p.strength}`;
-                        ctx.globalAlpha = 0.5;
-                        ctx.fillText(strengthText, textX + nameWidth, textY);
-                        ctx.globalAlpha = 1;
-                    }
-                }
-
-                ctx.textBaseline = "alphabetic";
-            
-                this._pillMap.push({ x: p.x, y: p.y, w: p.w, h: p.h, label: p.label, button: p.button });
-            }
-            
-            this._tagAreaBottom = currentY + pillH + padding;
-
-            // Reserve the pill area in the widget layout, so "control after generate"
-            // is placed below the pills instead of being drawn over them
-            if (this._pillAreaSpacer) {
-                this._pillAreaSpacer.spacerHeight = Math.max(0, this._tagAreaBottom - pillY);
-            }
-
-            // pill area + the control widget below it
-            this._measuredHeight = this._tagAreaBottom + LiteGraph.NODE_WIDGET_HEIGHT + 8 + padding;
-
-            // Height correction
-            if (isFinite(this._measuredHeight) && this._measuredHeight && this.size[1] !== this._measuredHeight) {
-                this.setSize([this.size[0], this._measuredHeight]);
-				this.setDirtyCanvas(true, true);
-            }
-
-        };
-        
-        const origResize = nodeType.prototype.onResize;
+        // Keep the node at the height the pill widget reports (legacy renderer only -
+        // Vue nodes size themselves from the DOM).
         nodeType.prototype.onResize = function () {
-            if (!this._measuredHeight) return;
-        
-            if (this.size[1] !== this._measuredHeight) {
-                this.setSize([this.size[0], this._measuredHeight]);
-                return;
+            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
+
+            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
+                this.setSize([this.size[0], this._erePillsHeight]);
             }
         };
 

--- a/web/prompt_randomizer.js
+++ b/web/prompt_randomizer.js
@@ -1,6 +1,6 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
-import { initializeSharedPromptFunctions, applyContextMenuPatch } from "./prompt.js";
+import { initializeSharedPromptFunctions, applyContextMenuPatch, addLayoutSpacer, getSpacerTop } from "./prompt.js";
 
 app.registerExtension({
     name: "ErePromptRandomizer",
@@ -38,8 +38,8 @@ app.registerExtension({
         if (nodeData.name !== "ErePromptRandomizer") return;
 
         // Shared layout constants
-        const pillX = 10, 
-              pillY = 30,
+        const pillX = 10,
+              pillYFallback = 30,
               pillH = 20,
               radius = 5,
               spacing = 5, 
@@ -63,15 +63,19 @@ app.registerExtension({
             textWidget.computeSize = () => [0, 0];
             textWidget.hidden = true;
 
+            // Reserves the pill area in the widget layout, so the control below never
+            // overlaps it. Height is kept in sync from onDrawForeground.
+            node._pillAreaSpacer = addLayoutSpacer(node, "erenodes_pill_area", 0);
+
             // Randomize control
-            const controlWidget = node.addWidget("combo", "control after generate", "fixed", "control_after_generate", { values: ["fixed", "increment", "decrement", "randomize"] });
+            node.addWidget("combo", "control after generate", "fixed", "control_after_generate", { values: ["fixed", "increment", "decrement", "randomize"] });
 
             node.onMouseDown = (e, pos) => {
 
                 const [x, y] = pos;
 
                 // Get background area
-                const bgX = 10, bgY = 30;
+                const bgX = 10, bgY = getSpacerTop(node._pillAreaSpacer, pillYFallback);
                 const bgW = node.size[0] - bgX * 2;
                 const bgH = node._tagAreaBottom - bgY;
                 if (x >= bgX && x <= bgX + bgW && y >= bgY && y <= bgY + bgH) {
@@ -134,6 +138,8 @@ app.registerExtension({
 
             ctx.font = "12px monospace";
 
+            // Anchor the pill area to the space reserved in the widget layout
+            const pillY = getSpacerTop(this._pillAreaSpacer, pillYFallback);
             const pillMaxWidth = this.size[0] - pillX * 2 - padding * 2;
             let currentX = pillX + padding;
             let currentY = pillY + padding;
@@ -272,10 +278,15 @@ app.registerExtension({
             }
             
             this._tagAreaBottom = currentY + pillH + padding;
-            this._measuredHeight = currentY + pillH + pillX + padding + 25; // extra for randomizer widget
 
-            // set hidden textWidget size to push randomize inpput down
-            textWidget.computeSize = () => [0, (currentY + pillH + padding * 2) - pillY];
+            // Reserve the pill area in the widget layout, so "control after generate"
+            // is placed below the pills instead of being drawn over them
+            if (this._pillAreaSpacer) {
+                this._pillAreaSpacer.spacerHeight = Math.max(0, this._tagAreaBottom - pillY);
+            }
+
+            // pill area + the control widget below it
+            this._measuredHeight = this._tagAreaBottom + LiteGraph.NODE_WIDGET_HEIGHT + 8 + padding;
 
             // Height correction
             if (isFinite(this._measuredHeight) && this._measuredHeight && this.size[1] !== this._measuredHeight) {

--- a/web/prompt_toggle.js
+++ b/web/prompt_toggle.js
@@ -1,5 +1,6 @@
 import { app } from "../../scripts/app.js";
 import { initializeSharedPromptFunctions, applyContextMenuPatch } from "./prompt.js";
+import { attachTagPillWidget } from "./js/pills.js";
 
 app.registerExtension({
     name: "ErePromptToggle",
@@ -11,22 +12,6 @@ app.registerExtension({
     beforeRegisterNodeDef(nodeType, nodeData, app) {
         if (nodeData.name !== "ErePromptToggle") return;
 
-        // Shared layout constants
-        const pillX = 10, 
-              pillY = 30,
-              pillH = 20,
-              radius = 5,
-              spacing = 5, 
-              padding = 5;
-
-        const parseTags = value => {
-            try {
-                const parsed = JSON.parse(value || "[]");
-                if (Array.isArray(parsed)) return parsed;
-            } catch {}
-            return [];
-        };
-
         const origCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             if (origCreated) origCreated.apply(this, arguments);
@@ -35,211 +20,37 @@ app.registerExtension({
 
             const textWidget = node.widgets?.find(w => w.name === "text");
             textWidget.computeSize = () => [0, 0];
+            // `hidden` hides it in the legacy renderer, `options.hidden` in Vue nodes -
+            // they read different flags, and without the second one the raw tag JSON
+            // shows up as a textarea.
             textWidget.hidden = true;
-
-            node.onMouseDown = (e, pos) => {
-
-                const [x, y] = pos;
-
-                // Get background area
-                const bgX = 10, bgY = 35;
-                const bgW = node.size[0] - bgX * 2;
-                const bgH = node._tagAreaBottom - bgY;
-                if (x >= bgX && x <= bgX + bgW && y >= bgY && y <= bgY + bgH) {
-
-                    // Find if we are clicking pill
-                    let clickedPill = null;
-                    for (const pill of node._pillMap || []) {
-                        if (x >= pill.x && x <= pill.x + pill.w && y >= pill.y && y <= pill.y + pill.h) {
-                            clickedPill = pill;
-                            break;
-                        }
-                    }
-
-                    // Handle normal toggle click and quick edit shift click
-                    if (clickedPill) {
-                        node.onTagPillClick(e, pos, clickedPill);
-                    } 
-
-                }
-
-            };
+            textWidget.options = textWidget.options || {};
+            textWidget.options.hidden = true;
 
             // Initialize all other functions shared between prompt nodes
             initializeSharedPromptFunctions(this, textWidget);
+
+            // Tag pills are a DOM widget so they render in both the legacy and the
+            // Vue node renderer; clicks are wired to the shared handlers inside.
+            attachTagPillWidget(node, {
+                variant: "toggle",
+                buttons: [
+                    { label: "button_menu", display: "≡", title: "Menu" },
+                    { label: "button_add_tag", display: "+", title: "Add tag" }
+                ]
+            });
+
             // Update on load
             this.onUpdateTextWidget(this);
-
         };
 
-        const origDraw = nodeType.prototype.onDrawForeground;
-        nodeType.prototype.onDrawForeground = function (ctx) {
-            if (origDraw) origDraw.call(this, ctx);
-
-            const textWidget = this.widgets?.find(w => w.name === "text");
-            if (!textWidget || this.flags?.collapsed) return;
-
-            const tagData = parseTags(this.properties?._tagDataJSON || "[]");
-
-            ctx.font = "12px monospace";
-
-            const pillMaxWidth = this.size[0] - pillX * 2;
-            let currentX = pillX;
-            let currentY = pillY;
-
-            const positions = [];
-            const specialTags = [
-                { label: "button_menu", display: "≡" },
-                { label: "button_add_tag", display: "+" }
-            ];
-    
-            // Creating buttons
-            for (const { display, label } of specialTags) {
-                if (currentX + pillH > pillX + pillMaxWidth - padding) {
-                    currentX = pillX + padding;
-                    currentY += pillH + spacing;
-                }
-                positions.push({ x: currentX, y: currentY, w: 20, h: 20, label, display, button: true });
-                currentX += pillH + spacing;
-            }
-
-            for (const tag of tagData) {
-
-                let label = tag.name;
-                let displayName = tag.name;
-                if (tag.type === 'lora') {
-                    // displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                    if (tag.triggers && tag.triggers.length > 0) {
-                        displayName += ` [+${tag.triggers.length}]`;
-                    }
-                } else if (tag.type === 'embedding') {
-                    displayName = displayName.replace(/^embedding:/, '');
-                } else if (tag.type === 'group') {
-                    // displayName = displayName.substring(Math.max(displayName.lastIndexOf('\\'), displayName.lastIndexOf('/')) + 1); // remove folders from name
-                    const dotIndex = displayName.lastIndexOf('.');
-                    if (dotIndex !== -1) displayName = displayName.substring(0, dotIndex);
-                }
-
-                let strengthText = "";
-                if (tag.strength && tag.strength !== 1.0) {
-                    tag.strength = tag.strength.toFixed(2);
-                    strengthText = ` ${tag.strength}`;
-                }
-
-                let display = displayName;
-                let strengthWidth = ctx.measureText(strengthText).width;
-                let textWidth = ctx.measureText(display).width + strengthWidth;
-
-                // Trim and append ellipsis if too wide
-                // Accomodate for toggle switch (35px) + padding
-                let maxTextWidth = pillMaxWidth - 35 - padding;
-                if (textWidth > maxTextWidth) {
-                    let i = display.length;
-                    const dots = "…";
-                    const dotsWidth = ctx.measureText("…").width;
-                    while (i > 0 && ctx.measureText(display.slice(0, i)).width + dotsWidth + strengthWidth > maxTextWidth ) i--;
-                    display = display.slice(0, i) + dots;
-                }
-
-                // calculate pill width
-                const pillW = pillMaxWidth;
-                
-                if (currentX + pillW > pillX + pillMaxWidth) {
-                    currentX = pillX;
-                    currentY += pillH + spacing;
-                }
-            
-                positions.push({ x: currentX, y: currentY, w: pillW, h: pillH, label, display, active: !tag.active, type: tag.type, strength: tag.strength });
-                currentX += pillW + spacing;
-            }
-
-            this._pillMap = [];
-
-            for (const p of positions) {
-                ctx.beginPath();
-                ctx.globalAlpha = p.button ? 1 : (p.active ? 0.75 : 1);
-                
-                let pillFill = LiteGraph.WIDGET_BGCOLOR;
-                ctx.fillStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? pillFill : LiteGraph.WIDGET_BGCOLOR);
-                ctx.roundRect(p.x, p.y, p.w, p.h, 6);
-                ctx.fill();
-            
-                ctx.strokeStyle = p.button ? LiteGraph.NODE_DEFAULT_BOXCOLOR : (p.active ? "#444" : pillFill);
-                ctx.lineWidth = 1;
-                ctx.stroke();
-
-                ctx.textBaseline = "middle";
-                const textX = p.x + (p.button ? p.w / 2 : 35);
-                const textY = p.y + p.h / 2 + 1;
-
-                if(p.button) {
-                    ctx.textAlign = "center";
-                    ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-                    ctx.fillText(p.display, textX, textY);
-                } else {
-                    ctx.strokeStyle = "#444";
-                    ctx.lineWidth = 1;
-                    ctx.stroke();
-
-                    ctx.beginPath();
-                    ctx.fillStyle = "#3b3b3b";
-                    ctx.roundRect(p.x + radius, p.y + padding, 18, p.h - padding * 2, radius);
-                    ctx.fill();
-
-                    ctx.beginPath();
-                    let pillFill = "#8899bb";
-                    if (p.type === 'lora') {
-                        pillFill = "#89a189";
-                    } else if (p.type === 'embedding') {
-                        pillFill = "#9b8899  ";
-                    } else if (p.type === 'group') {
-                        pillFill = "#9b9188";
-                    }
-                    ctx.fillStyle = p.active ? "#888" : pillFill;
-                    const r = 7;
-                    const cx = p.x + (p.active ?  r + 4 : 18 - r + 8);
-                    const cy = p.y + p.h / 2;
-                    ctx.arc(cx, cy, r, 0, 2 * Math.PI);
-                    ctx.fill();
-
-                    ctx.textAlign = "left";
-                    ctx.fillStyle = (p.active ? LiteGraph.WIDGET_TEXT_COLOR : "#FFF");
-                    ctx.fillText(p.display, textX, textY);
-
-                    if (p.strength && p.strength !== 1.0) {
-                        const nameWidth = ctx.measureText(p.display).width;
-                        const strengthText = ` ${p.strength}`;
-                        ctx.globalAlpha = 0.5;
-                        ctx.fillText(strengthText, textX + nameWidth, textY);
-                        ctx.globalAlpha = 1;
-                    }
-                }
-
-                ctx.textBaseline = "alphabetic";
-                
-                this._pillMap.push({ x: p.x, y: p.y, w: p.w, h: p.h, label: p.label, button: p.button });
-            }
-            
-            this._tagAreaBottom = currentY + pillH + padding;
-            this._measuredHeight = currentY + pillH + pillX;
-
-            // Height correction
-            if (isFinite(this._measuredHeight) && this._measuredHeight && this.size[1] !== this._measuredHeight) {
-                this.setSize([this.size[0], this._measuredHeight]);
-				this.setDirtyCanvas(true, true);
-            }
-
-        };
-        
-        const origResize = nodeType.prototype.onResize;
+        // Keep the node at the height the pill widget reports (legacy renderer only -
+        // Vue nodes size themselves from the DOM).
         nodeType.prototype.onResize = function () {
-            if (!this._measuredHeight) return;
-        
-            if (this.size[1] !== this._measuredHeight) {
-                this.setSize([this.size[0], this._measuredHeight]);
-                return;
+            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
+
+            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
+                this.setSize([this.size[0], this._erePillsHeight]);
             }
         };
 

--- a/web/prompt_toggle.js
+++ b/web/prompt_toggle.js
@@ -44,15 +44,5 @@ app.registerExtension({
             this.onUpdateTextWidget(this);
         };
 
-        // Keep the node at the height the pill widget reports (legacy renderer only -
-        // Vue nodes size themselves from the DOM).
-        nodeType.prototype.onResize = function () {
-            if (LiteGraph.vueNodesMode || !this._erePillsHeight) return;
-
-            if (Math.abs(this.size[1] - this._erePillsHeight) > 1) {
-                this.setSize([this.size[0], this._erePillsHeight]);
-            }
-        };
-
     }
 });


### PR DESCRIPTION
## Why

Two breakages on recent frontends:

- **Current frontend (Vue nodes off).** Global autocomplete threw on every
  textarea focus, and hidden widgets stopped reserving layout space, so the
  Multiline button sat under the textarea and the Randomizer control drew
  over the pills.
- **Vue nodes 2.0.** `LGraphCanvas.drawNode()` returns before any node body
  drawing, so `onDrawForeground`, `node.onMouseDown` and the
  `processContextMenu` patch never run - the nodes rendered as a bare
  textarea with the raw tag JSON.

## What

- Fix a `ReferenceError` on an undefined `triggerImmediately` that killed
  autocomplete attach for node textareas.
- Isolate the autocomplete menu entries from the single-line
  `.litemenu-entry` styles so alias rows no longer overlap the tag name.
- Fix the quick edit menu for loras and groups: the trigger/content panel
  did not grow with its wrapped pill rows, so the items below it were laid
  out over the tags, and a name longer than the menu is wide covered the
  strength control. Rows are pinned to auto height, pills shrink as flex
  items, and long names wrap mid-word.
- Move the pill area to a DOM widget (`web/js/pills.js`) with toggle / chips
  / gallery / buttons variants - the legacy renderer mounts it in the
  DomWidgets overlay, Vue nodes mount it inside the node, one implementation
  for both. Removes ~1300 lines of duplicated canvas drawing.
- Hide the tag JSON widget via `options.hidden` as well - Vue nodes read that
  flag rather than `widget.hidden`.
- Theme the buttons from the `--component-node-*` variables instead of the
  litegraph constants.
- Keep autocomplete inside EreNodes prompt inputs when Global Autocomplete
  is turned off, with a separate setting to opt out. Users disable the
  global one because it collides with other extensions' autocomplete, and
  lose suggestions in the prompt nodes as a side effect (#11).
- Let the tag area scroll so a node with many tags can be squeezed instead
  of growing until it covers its neighbours; the height is auto-fitted
  until the node is resized by hand, and a menu entry restores the fit (#4).

## Notes

- Gallery drops the manual bitmap cache (plain `<img>`, browser cache) and
  the width snapping (cards reflow via CSS) - width is now freely resizable.
- Tested manually in both renderers; the `processContextMenu` patch is now
  dead for pill right-clicks but still injects the quick-edit input styles,
  so it was left in place.
- The quick edit panel lost its hardcoded 256px cap and the entry background
  that showed through as a coloured block, so for loras with many triggers
  the menu is now about as wide as the node instead of a narrow column.

Fixes #14
Fixes #11
Fixes #4